### PR TITLE
Add redesigned homepage layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,28 +1,6 @@
 import React from "react";
+import Home from "./pages/Home";
 
 export default function App() {
-  return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-neutral dark:bg-gray-900">
-      <header className="text-center mb-12">
-        <h1 className="text-4xl md:text-5xl font-display text-primary mb-4">
-          MyFreeStocks
-        </h1>
-        <p className="text-gray-600 dark:text-gray-300 max-w-xl mx-auto">
-          Discover free stock offers, market data, and brokerage rewards — all in one clean, modern dashboard.
-        </p>
-      </header>
-
-      <div className="card w-11/12 md:w-2/3 text-center">
-        <h2 className="text-2xl font-display mb-3 text-primary">Start Earning</h2>
-        <p className="mb-6 text-gray-600 dark:text-gray-300">
-          Connect with top brokers and claim your free stock rewards today.
-        </p>
-        <button className="btn-primary">View Offers</button>
-      </div>
-
-      <footer className="mt-16 text-sm text-gray-500 dark:text-gray-400">
-        © {new Date().getFullYear()} MyFreeStocks — Built with ❤️ and React
-      </footer>
-    </div>
-  );
+  return <Home />;
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,8 +1,19 @@
+import React from "react";
+
 export default function Footer() {
   return (
-    <footer className="text-center py-8 text-sm text-gray-500 dark:text-gray-400 border-t dark:border-gray-700 mt-10">
-      © 2025 MyFreeStocks · Built with ❤️ by the MyFreeStocks Team · 
-      <a href="https://github.com/dregna/myfreestocks" className="text-green-600 hover:underline ml-1">GitHub</a>
+    <footer className="border-t border-gray-200 py-6 px-6 text-sm text-gray-500">
+      <div className="flex flex-col md:flex-row justify-between items-center">
+        <div className="flex items-center space-x-2 mb-3 md:mb-0">
+          <img src="/favicon.svg" className="h-5 w-5" alt="Logo" />
+          <span>© {new Date().getFullYear()} MyFreeStocks</span>
+        </div>
+        <div className="space-x-4">
+          <a href="#" className="hover:text-primary">Disclosure</a>
+          <a href="#" className="hover:text-primary">Privacy</a>
+          <a href="#" className="hover:text-primary">Terms</a>
+        </div>
+      </div>
     </footer>
   );
 }

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,11 +1,27 @@
+import React from "react";
+
 export default function Hero() {
   return (
-    <section className="flex flex-col items-center text-center py-20 px-6 bg-gradient-to-b from-green-100 to-white dark:from-gray-900 dark:to-black">
-      <h2 className="text-4xl md:text-6xl font-extrabold text-green-700 dark:text-green-400 mb-4">Track. Earn. Grow.</h2>
-      <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mb-8">Your gateway to free stocks, live market data, and smarter investing.</p>
-      <div className="flex gap-4">
-        <a href="#" className="bg-green-600 text-white px-6 py-3 rounded-xl hover:bg-green-700 transition">View Free Offers</a>
-        <a href="#" className="border border-green-600 text-green-600 px-6 py-3 rounded-xl hover:bg-green-50 dark:hover:bg-green-900 transition">Join the Community</a>
+    <section className="grid md:grid-cols-2 gap-8 items-center py-16 px-6">
+      <div>
+        <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
+          Earn bonuses while you invest.
+        </h1>
+        <p className="text-gray-600 mb-6">
+          Track real-time markets and sign-up incentives from top brokers and advisors.
+        </p>
+        <button className="bg-primary text-white px-6 py-3 rounded-lg hover:bg-secondary transition-all">
+          See Today’s Top Offers
+        </button>
+      </div>
+      <div className="bg-white p-6 shadow-card rounded-xl border border-gray-100">
+        <h3 className="text-lg font-semibold mb-3">Market Overview</h3>
+        <ul className="text-sm text-gray-700 space-y-2">
+          <li className="flex justify-between"><span>US Indices</span><span className="text-green-600">+0.56%</span></li>
+          <li className="flex justify-between"><span>Futures</span><span className="text-green-600">+0.23%</span></li>
+          <li className="flex justify-between"><span>Crypto</span><span className="text-red-500">-0.27%</span></li>
+          <li className="flex justify-between"><span>Forex</span><span className="text-green-600">+0.41%</span></li>
+        </ul>
       </div>
     </section>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,12 +1,24 @@
+import React from "react";
+
 export default function Navbar() {
   return (
-    <nav className="flex justify-between items-center py-4 px-6 bg-white dark:bg-gray-900 shadow-md">
-      <h1 className="text-2xl font-bold text-green-600">MyFreeStocks</h1>
-      <ul className="flex space-x-6 text-gray-700 dark:text-gray-300">
-        <li><a href="#" className="hover:text-green-500">Home</a></li>
-        <li><a href="#" className="hover:text-green-500">Offers</a></li>
-        <li><a href="#" className="hover:text-green-500">News</a></li>
+    <nav className="flex justify-between items-center py-4 px-6 border-b border-gray-200 bg-white">
+      <div className="flex items-center space-x-2">
+        <img src="/favicon.svg" alt="MyFreeStocks" className="h-6 w-6" />
+        <span className="font-semibold text-gray-800 text-lg">myfreestocks</span>
+      </div>
+      <ul className="hidden md:flex space-x-6 text-gray-700">
+        <li><a href="#" className="hover:text-primary">Promotions</a></li>
+        <li><a href="#" className="hover:text-primary">Robo-Advisors</a></li>
+        <li><a href="#" className="hover:text-primary">Learn</a></li>
       </ul>
+      <div className="flex items-center space-x-4">
+        <button className="hidden md:block text-gray-500 hover:text-gray-800">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </button>
+      </div>
     </nav>
   );
 }

--- a/src/components/Promotions.jsx
+++ b/src/components/Promotions.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const promos = [
+  { name: "Webull", desc: "Up to 12 free stocks", cta: "Get Bonus" },
+  { name: "Robinhood", desc: "A free stock", cta: "Get Bonus" },
+  { name: "Schwab", desc: "Up to $100", cta: "Get Bonus" },
+  { name: "Betterment", desc: "Up to $500", cta: "Get Bonus" },
+];
+
+export default function Promotions() {
+  return (
+    <section className="px-6 py-10">
+      <h2 className="text-2xl font-bold mb-2">Promotions</h2>
+      <p className="text-gray-600 mb-6">
+        Brokerage and robo-advisor bonuses change often. We track today’s top sign-up incentives so you can start investing with an edge.
+      </p>
+      <div className="grid md:grid-cols-4 sm:grid-cols-2 gap-4">
+        {promos.map((promo) => (
+          <div key={promo.name} className="card text-center">
+            <h3 className="font-semibold text-lg mb-2">{promo.name}</h3>
+            <p className="text-gray-500 mb-4">{promo.desc}</p>
+            <button className="btn-primary w-full">{promo.cta}</button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/RoboAdvisorTable.jsx
+++ b/src/components/RoboAdvisorTable.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+export default function RoboAdvisorTable() {
+  return (
+    <section className="px-6 py-10">
+      <h2 className="text-2xl font-bold mb-4">Robo-Advisor Spotlight</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse border border-gray-200 text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="p-3 border">Provider</th>
+              <th className="p-3 border">Annual Fee</th>
+              <th className="p-3 border">Account Minimum</th>
+              <th className="p-3 border">Tax Loss Harvesting</th>
+              <th className="p-3 border">Signup Bonus</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="p-3 border font-medium">Betterment</td>
+              <td className="p-3 border">0.25%</td>
+              <td className="p-3 border">$0</td>
+              <td className="p-3 border">Yes</td>
+              <td className="p-3 border">Up to $500</td>
+            </tr>
+            <tr>
+              <td className="p-3 border font-medium">Wealthfront</td>
+              <td className="p-3 border">0.25%</td>
+              <td className="p-3 border">$5,000</td>
+              <td className="p-3 border">Yes</td>
+              <td className="p-3 border">$100</td>
+            </tr>
+            <tr>
+              <td className="p-3 border font-medium">Schwab</td>
+              <td className="p-3 border">0%</td>
+              <td className="p-3 border">$0</td>
+              <td className="p-3 border">Limited</td>
+              <td className="p-3 border">Up to $100</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/TickerBar.jsx
+++ b/src/components/TickerBar.jsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from "react";
+
+const SYMBOLS = ["AAPL", "TSLA", "SPY", "BTC-USD", "ETH-USD"];
+
+function formatNumber(value) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  return value.toFixed(2);
+}
+
+export default function TickerBar() {
+  const [quotes, setQuotes] = useState([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchData() {
+      try {
+        const symbolsQuery = SYMBOLS.join(",");
+        const response = await fetch(
+          `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${symbolsQuery}`
+        );
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const payload = await response.json();
+        const results = payload?.quoteResponse?.result ?? [];
+        if (isMounted) {
+          setQuotes(
+            results.map((quote) => ({
+              symbol: quote.symbol,
+              price: quote.regularMarketPrice,
+              change: quote.regularMarketChangePercent,
+            }))
+          );
+        }
+      } catch (error) {
+        console.error("Ticker fetch failed:", error);
+        if (isMounted) {
+          setQuotes([]);
+        }
+      }
+    }
+
+    fetchData();
+    const interval = setInterval(fetchData, 60_000);
+
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div className="bg-primary text-white text-sm py-2 overflow-hidden">
+      <div className="animate-marquee whitespace-nowrap">
+        {quotes.length === 0 && (
+          <span className="mx-6 opacity-80">Live quotes unavailable</span>
+        )}
+        {quotes.map((quote) => {
+          const priceText = formatNumber(quote.price);
+          const isChangeNumber =
+            typeof quote.change === "number" && !Number.isNaN(quote.change);
+          const isPositive = isChangeNumber && quote.change >= 0;
+          const changeText = isChangeNumber ? formatNumber(quote.change) : "—";
+          const changeClass = isChangeNumber
+            ? isPositive
+              ? "text-green-200"
+              : "text-red-200"
+            : "text-white/70";
+          const changeSymbol = !isChangeNumber ? "•" : isPositive ? "▲" : "▼";
+          return (
+            <span key={quote.symbol} className="mx-6 inline-flex items-center gap-1">
+              <span className="font-semibold">{quote.symbol}</span>
+              <span>{priceText}</span>
+              <span className={changeClass}>
+                {changeSymbol} {changeText}
+                {isChangeNumber ? "%" : ""}
+              </span>
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -18,3 +18,17 @@ body {
 h1, h2, h3, h4 {
   @apply font-display;
 }
+
+@keyframes marquee {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+.animate-marquee {
+  display: inline-block;
+  animation: marquee 40s linear infinite;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import TickerBar from "../components/TickerBar";
+import Navbar from "../components/Navbar";
+import Hero from "../components/Hero";
+import Promotions from "../components/Promotions";
+import RoboAdvisorTable from "../components/RoboAdvisorTable";
+import Footer from "../components/Footer";
+
+export default function Home() {
+  return (
+    <div className="bg-neutral text-gray-900">
+      <TickerBar />
+      <Navbar />
+      <Hero />
+      <Promotions />
+      <RoboAdvisorTable />
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a dedicated Home page that composes the navbar, hero, promotions, robo table, and footer sections
- redesign the hero, navigation, and footer components to match the new layout and add promotions and robo-advisor table components
- add a live market ticker bar component that fetches Yahoo Finance quotes, animates them with a marquee, and surfaces it above the homepage navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1cbc3820483328d9f159a22586724