### PR TITLE
feat: redesign offers page for MyFreeStock Score hub

### DIFF
--- a/src/pages/offers.jsx
+++ b/src/pages/offers.jsx
@@ -160,22 +160,27 @@ export default function OffersPage() {
       <main className="mx-auto max-w-6xl px-4">
         <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)]">
           <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
-            <div>
+            <div className="space-y-6">
               <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
                 MyFreeStock Score™
               </div>
-              <h1 className="mt-6 text-4xl font-extrabold tracking-tight text-white sm:text-5xl lg:text-6xl">
-                Compare Brokerages — MyFreeStock Score™
-              </h1>
-              <p className="mt-6 text-lg text-slate-300">
-                Dive into every live brokerage promotion ranked by our proprietary scoring model. Review headline bonuses, funding requirements, and platform strengths without leaving the MyFreeStocks ecosystem.
+              <div>
+                <h1 className="text-4xl font-extrabold tracking-tight text-white sm:text-5xl lg:text-6xl">
+                  The MyFreeStock Score™ System
+                </h1>
+                <p className="mt-4 text-lg text-slate-300">
+                  Independent ratings for brokers and robo-advisors
+                </p>
+              </div>
+              <p className="text-base text-slate-300 sm:text-lg">
+                The Score™ measures transparency, cost, platform features, customer support, and historical returns. Each category is weighted into a 0–100 composite that refreshes every week so you can track who leads the market in real time.
               </p>
-              <div className="mt-8 flex flex-wrap items-center gap-4">
+              <div className="flex flex-wrap items-center gap-4">
                 <a
-                  href="#rankings"
+                  href="#scores"
                   className="rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/40 transition hover:scale-[1.02]"
                 >
-                  View Rankings
+                  Compare All Scores
                 </a>
                 <Link
                   to="/"
@@ -186,7 +191,7 @@ export default function OffersPage() {
               </div>
             </div>
             {summary.topOffer && (
-              <div className="relative rounded-[36px] border border-emerald-400/20 bg-[#0A152E] p-8 shadow-xl">
+              <div className="relative overflow-hidden rounded-[36px] border border-emerald-400/20 bg-[#0A152E] p-8 shadow-xl">
                 <div className="absolute inset-0 -translate-y-6 translate-x-6 rounded-[40px] bg-emerald-500/20 blur-3xl" />
                 <div className="relative space-y-6">
                   <div className="flex items-center justify-between">
@@ -195,14 +200,14 @@ export default function OffersPage() {
                     </span>
                     <ScoreBadge score={summary.topOffer.computedScore} />
                   </div>
-                  <div>
+                  <div className="space-y-2">
                     <p className="text-2xl font-bold text-white">{summary.topOffer.name}</p>
-                    <p className="mt-2 text-sm text-slate-300">
-                      Weighted scoring favors transparent pricing, platform reliability, and support quality so you can choose the right brokerage in minutes.
+                    <p className="text-sm text-slate-300">
+                      Our toolkit highlights standout offers where balanced pricing, robust tools, and long-term performance align.
                     </p>
                   </div>
                   <div className="flex items-baseline justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-slate-300">
-                    <span>Portfolio average</span>
+                    <span>Scoreboard Average</span>
                     <span className="text-xl font-semibold text-white">{summary.averageScore}</span>
                   </div>
                   <a
@@ -219,29 +224,130 @@ export default function OffersPage() {
           </div>
         </section>
 
-        <section className="mt-12">
-          <div className="rounded-3xl border border-emerald-400/20 bg-[#071025] p-6">
-            <div className="flex flex-wrap items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-300">
-                  Filter Toolkit
-                </p>
-                <p className="mt-2 max-w-2xl text-sm text-slate-300">
-                  Sorting by deposit requirements, payout timelines, and account features is coming soon. Our team is finalizing interactive filters so you can tailor the MyFreeStock Score™ list to your goals.
-                </p>
-              </div>
-              <button
-                type="button"
-                disabled
-                className="inline-flex items-center justify-center rounded-full border border-white/10 px-5 py-2 text-sm font-semibold text-slate-300 opacity-70"
+        <section className="mt-10">
+          <div className="grid gap-4 rounded-3xl border border-emerald-400/20 bg-[#071025] p-6 sm:grid-cols-2 lg:grid-cols-5">
+            {[
+              { label: "Transparency", weight: "25%" },
+              { label: "Cost", weight: "20%" },
+              { label: "Features", weight: "20%" },
+              { label: "Support", weight: "15%" },
+              { label: "Returns", weight: "20%" },
+            ].map((metric) => (
+              <div
+                key={metric.label}
+                className="flex flex-col items-center rounded-2xl bg-white/5 p-4 text-center text-slate-200 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]"
               >
-                Filters Locked
-              </button>
+                <span className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/15 text-sm font-semibold text-emerald-300">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    className="h-5 w-5"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 3v18m9-9H3"
+                    />
+                  </svg>
+                </span>
+                <p className="text-sm font-semibold text-white">{metric.label}</p>
+                <p className="mt-1 text-xs uppercase tracking-[0.25em] text-emerald-300">{metric.weight}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-12 rounded-3xl border border-emerald-400/20 bg-[#09152B] p-10 text-slate-200 shadow-[0_30px_90px_-60px_rgba(16,185,129,0.6)]">
+          <div className="mx-auto max-w-4xl text-center">
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">How We Calculate the Score</h2>
+            <p className="mt-4 text-base text-slate-300">
+              Each category is reviewed with a proprietary rubric that weights objective data, platform disclosures, and real user feedback. We rebalance weekly to reflect product launches, pricing shifts, and new regulatory updates.
+            </p>
+          </div>
+          <div className="mt-10 grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+            <div className="space-y-4">
+              {["Transparency digs into fee clarity and disclosures.", "Cost covers commissions, spreads, and account minimums.", "Features evaluate investing tools, automation, and integrations.", "Support measures human and digital help options.", "Returns tracks historical performance where disclosed."].map(
+                (item) => (
+                  <div key={item} className="flex items-start gap-3 rounded-2xl border border-emerald-400/10 bg-[#0B1A33] p-4">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" />
+                    <p className="text-sm text-slate-200">{item}</p>
+                  </div>
+                )
+              )}
+            </div>
+            <div className="flex items-center justify-center">
+              <div className="relative flex h-56 w-56 items-center justify-center rounded-full border-2 border-emerald-400/40 bg-[#0B1A33] shadow-inner shadow-emerald-500/20">
+                <div className="absolute inset-4 rounded-full border border-emerald-400/30" />
+                <div className="absolute inset-2 rounded-full bg-gradient-to-br from-emerald-500/20 via-transparent to-transparent" />
+                <div className="text-center">
+                  <p className="text-xs uppercase tracking-[0.25em] text-emerald-300">Weighting</p>
+                  <p className="mt-2 text-3xl font-bold text-white">0 – 100</p>
+                  <p className="mt-1 text-xs text-slate-300">Updated Weekly</p>
+                </div>
+              </div>
             </div>
           </div>
         </section>
 
-        <section id="rankings" className="mt-12">
+        <section className="mt-12 rounded-3xl border border-emerald-400/20 bg-[#071025] p-10 shadow-[0_30px_90px_-70px_rgba(16,185,129,0.6)]">
+          <div className="flex flex-col gap-4 text-center">
+            <span className="mx-auto rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+              Toolkit
+            </span>
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">The MyFreeStocks Toolkit</h2>
+            <p className="mx-auto max-w-2xl text-base text-slate-300">
+              Pair the Score™ with specialized research workflows designed to keep your investing stack transparent and opportunity-ready.
+            </p>
+          </div>
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {[
+              {
+                title: "Free Stock Offer Tracker",
+                description:
+                  "Monitor every live brokerage incentive with auto-refreshing terms, deadlines, and funding requirements.",
+              },
+              {
+                title: "Robo-Advisor Comparison",
+                description:
+                  "Benchmark automation styles, portfolio mixes, and advisory fees with filters made for both beginners and pros.",
+              },
+              {
+                title: "Data Transparency Dashboard",
+                description:
+                  "Review disclosures, regulatory filings, and service-level agreements directly inside your Score™ workspace.",
+              },
+            ].map((tool) => (
+              <div
+                key={tool.title}
+                className="group flex flex-col gap-4 rounded-3xl border border-white/5 bg-[#0B1A33]/80 p-6 text-left shadow-[0_25px_60px_-50px_rgba(16,185,129,0.6)] transition hover:border-emerald-400/50 hover:shadow-emerald-500/20"
+              >
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-300">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    className="h-6 w-6"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M4 7h16M4 12h16M4 17h10"
+                    />
+                  </svg>
+                </span>
+                <div className="space-y-2">
+                  <h3 className="text-xl font-semibold text-white">{tool.title}</h3>
+                  <p className="text-sm text-slate-300">{tool.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section id="scores" className="mt-12">
           <div className="flex flex-col gap-4 text-center">
             <span className="mx-auto rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
               Ranked Brokerages


### PR DESCRIPTION
## Summary
- rebuild the /offers hero into a dedicated MyFreeStock Score overview with refreshed copy and CTA
- add category weighting metrics row, methodology explainer, and toolkit feature cards styled in the dark emerald theme
- retain the score card leaderboard while updating section anchors for the new layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fa9f89b8833281c274174f5c9428