### PR TITLE
feat: add broker deep-dive review pages

### DIFF
--- a/src/components/offers/BrokerOfferCard.jsx
+++ b/src/components/offers/BrokerOfferCard.jsx
@@ -11,6 +11,8 @@ function normaliseMetrics(breakdown = {}) {
 
 export default function BrokerOfferCard({ offer }) {
   const {
+    id,
+    slug,
     name,
     headline,
     summary,
@@ -152,6 +154,7 @@ export default function BrokerOfferCard({ offer }) {
             subMetrics={breakdown}
             type="broker"
             scoreOverride={displayScore}
+            slug={slug ?? id}
           />
           {idealFor.length > 0 && (
             <div className="rounded-2xl border border-gray-200 bg-accent/60 p-4 text-sm text-gray-700">

--- a/src/components/score/ScoreCard.jsx
+++ b/src/components/score/ScoreCard.jsx
@@ -1,5 +1,6 @@
 // src/components/score/ScoreCard.jsx
 import React from "react";
+import { Link } from "react-router-dom";
 import ScoreBadge from "./ScoreBadge";
 
 /**
@@ -20,6 +21,7 @@ export default function ScoreCard({
   scoreOverride,
   variant = "light",
   className = "",
+  slug,
 }) {
   // Basic weighted display pulled from same philosophy as score.js (already normalized)
   const metricLabels = {
@@ -82,8 +84,12 @@ export default function ScoreCard({
             "mt-4 text-sm text-gray-600 dark:text-gray-400",
         };
 
-  return (
-    <div className={variantStyles.container}>
+  const containerClassName = `${variantStyles.container} ${
+    slug ? "cursor-pointer" : ""
+  }`;
+
+  const cardContent = (
+    <div className={containerClassName}>
       <div className="mb-4 flex items-center justify-between">
         <h3 className={variantStyles.heading}>{name}</h3>
         <ScoreBadge score={Math.round(score)} />
@@ -109,6 +115,20 @@ export default function ScoreCard({
         glance.
       </div>
     </div>
+  );
+
+  if (!slug) {
+    return cardContent;
+  }
+
+  return (
+    <Link
+      to={`/broker/${slug}`}
+      className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+      aria-label={`View the MyFreeStock deep-dive review for ${name}`}
+    >
+      {cardContent}
+    </Link>
   );
 }
 

--- a/src/data/brokers.json
+++ b/src/data/brokers.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "webull",
+    "slug": "webull",
     "name": "Webull",
     "headline": "Earn up to 12 free stocks worth as much as $30,600 when you deposit $100",
     "summary": "Webull leads our rankings for self-directed traders with aggressive equity bonuses and a professional-grade mobile and desktop platform.",
@@ -20,6 +21,56 @@
       "Paper trading and in-app trading journal"
     ],
     "idealFor": ["Active traders", "Mobile-first investors"],
+    "logo": "https://logo.clearbit.com/webull.com",
+    "bestFor": ["Active options traders", "DIY investors who crave analytics"],
+    "strengths": [
+      "Institutional-grade charting across mobile and desktop",
+      "Free Level 2 quotes and real-time market data packages",
+      "Hybrid cash management with 5.0% APY sweep"
+    ],
+    "cautions": [
+      "No access to mutual funds, bonds, or futures",
+      "Learning curve for brand-new investors",
+      "Phone support limited to callbacks"
+    ],
+    "currentPromo": "Earn up to 12 free stocks (valued $36 – $30,600) when you deposit $100 within 10 days.",
+    "about": "Webull is a technology-first brokerage built for active investors who value sleek execution tools, low costs, and constant market access. The platform pairs customizable workstations with powerful mobile charting, while still keeping trading commissions at zero.",
+    "features": [
+      {
+        "name": "Advanced Charting Suite",
+        "description": "Multi-chart layouts, 50+ technical indicators, and synchronized watchlists across every device."
+      },
+      {
+        "name": "Paper Trading Sandbox",
+        "description": "Simulate strategies with $1M in virtual funds and export performance to share with mentors or communities."
+      },
+      {
+        "name": "Extended-Hours Sessions",
+        "description": "Trade from 4 a.m. to 8 p.m. ET to react to global catalysts without paying additional fees."
+      },
+      {
+        "name": "Cash Management",
+        "description": "FDIC-insured sweep accounts with up to 5.0% APY and instant transfers back into trading balances."
+      }
+    ],
+    "feesAndMinimums": {
+      "managementFee": "$0 trading commissions on stocks, ETFs, and options",
+      "productFees": "Regulatory and clearing fees (SEC/TAF) passed through at cost",
+      "accountMinimum": "$0 minimum to open or maintain",
+      "accountTypes": "Taxable brokerage, Traditional & Roth IRA, Rollover IRA"
+    },
+    "prosCons": {
+      "pros": [
+        "Feature-rich platform rivals pro desktop terminals",
+        "Aggressive promotional stock rewards for new clients",
+        "Robust options analytics including Greeks and strategy builder"
+      ],
+      "cons": [
+        "No mutual funds or fixed-income desk",
+        "Limited financial planning guidance",
+        "Customer support relies heavily on chat and tickets"
+      ]
+    },
     "score": {
       "vertical": "broker",
       "breakdown": {
@@ -27,12 +78,22 @@
         "features": 88,
         "platform": 91,
         "support": 76
+      },
+      "deepDive": {
+        "transparency": { "weight": 0.2, "score": 86 },
+        "cost": { "weight": 0.2, "score": 94 },
+        "features": { "weight": 0.25, "score": 91 },
+        "support": { "weight": 0.2, "score": 76 },
+        "returns": { "weight": 0.15, "score": 82 }
       }
     },
+    "finalVerdict": "Webull remains a compelling pick for data-driven traders who want pro-level analytics without paying platform fees. If you can handle a more technical interface, the bonus stock offer and robust options desk make Webull difficult to beat.",
+    "referralUrl": "https://www.webull.com/",
     "disclaimer": "Promotional share values fluctuate with market prices. New U.S. customers only; terms and conditions from Webull Financial LLC apply."
   },
   {
     "id": "robinhood",
+    "slug": "robinhood",
     "name": "Robinhood",
     "headline": "Get up to $200 in free stock slices when you open and fund a brokerage account",
     "summary": "Robinhood balances low costs with user-friendly automation, making it a popular entry point for new investors seeking fractional share bonuses.",
@@ -52,6 +113,56 @@
       "Cash sweep with up to 5.0% APY for Gold members"
     ],
     "idealFor": ["Beginner investors", "DIY retirement savers"],
+    "logo": "https://logo.clearbit.com/robinhood.com",
+    "bestFor": ["First-time investors", "Goal-based savers who value automation"],
+    "strengths": [
+      "Simple mobile-first interface with zero commissions",
+      "Recurring investments and automated dividend reinvestment",
+      "Access to IPO allocations and 24-hour market coverage"
+    ],
+    "cautions": [
+      "Advanced order types still limited",
+      "Customer support wait times can spike during volatility",
+      "Cash sweep APY requires paid Gold membership"
+    ],
+    "currentPromo": "Deposit $50 to unlock up to $200 in randomized stock rewards within five trading days.",
+    "about": "Robinhood popularized commission-free trading by stripping away complexity and focusing on a clean, mobile-first investing experience. Its automation tools and educational nudges help new investors build habits without feeling overwhelmed.",
+    "features": [
+      {
+        "name": "Fractional Shares",
+        "description": "Invest in thousands of stocks and ETFs with as little as $1, keeping portfolios diversified."
+      },
+      {
+        "name": "Recurring Investments",
+        "description": "Schedule automated deposits into chosen securities weekly, biweekly, or monthly."
+      },
+      {
+        "name": "24-Hour Market",
+        "description": "Trade select large-cap stocks almost around the clock to react to global news."
+      },
+      {
+        "name": "Gold Research",
+        "description": "Premium Morningstar reports, Level II data, and 5.0% cash sweep yield for Gold subscribers."
+      }
+    ],
+    "feesAndMinimums": {
+      "managementFee": "$0 trading commissions across stocks, ETFs, and options",
+      "productFees": "$5 monthly for Robinhood Gold (optional)",
+      "accountMinimum": "$0 minimum balance required",
+      "accountTypes": "Taxable brokerage, Traditional & Roth IRA, SEP IRA"
+    },
+    "prosCons": {
+      "pros": [
+        "Onboarding takes minutes with instant account approval",
+        "Helpful automation like recurring investments and dividend reinvestment",
+        "Crypto, options, and IPO access inside a single app"
+      ],
+      "cons": [
+        "Gold membership needed for highest APY and research",
+        "Limited advanced charting and analytics",
+        "Customer service improving but still inconsistent"
+      ]
+    },
     "score": {
       "vertical": "broker",
       "breakdown": {
@@ -59,12 +170,22 @@
         "features": 82,
         "platform": 85,
         "support": 72
+      },
+      "deepDive": {
+        "transparency": { "weight": 0.22, "score": 84 },
+        "cost": { "weight": 0.2, "score": 90 },
+        "features": { "weight": 0.23, "score": 84 },
+        "support": { "weight": 0.2, "score": 72 },
+        "returns": { "weight": 0.15, "score": 78 }
       }
     },
+    "finalVerdict": "Robinhood is the most approachable path to start investing thanks to automation, fractional shares, and a slick app. Experienced traders will still crave deeper analytics, but for everyday savers the current promo and habit-building workflows are hard to ignore.",
+    "referralUrl": "https://robinhood.com/",
     "disclaimer": "Stock slice values are randomized at the time of distribution. Check Robinhood's latest disclosures for eligibility limitations and tax reporting guidance."
   },
   {
     "id": "fidelity",
+    "slug": "fidelity",
     "name": "Fidelity",
     "headline": "Earn up to $100 cash bonus with qualifying deposits into a new Fidelity brokerage account",
     "summary": "Fidelity pairs a cash welcome bonus with industry-leading research, zero trade commissions, and award-winning customer support.",
@@ -84,6 +205,56 @@
       "24/7 phone, chat, and in-branch support nationwide"
     ],
     "idealFor": ["Long-term investors", "Retirement planning"],
+    "logo": "https://logo.clearbit.com/fidelity.com",
+    "bestFor": ["Long-term wealth builders", "Retirement-focused households"],
+    "strengths": [
+      "Institutional-grade research from Fidelity and third parties",
+      "Extensive lineup of zero-expense-ratio index funds",
+      "Nationwide in-person support and 24/7 service"
+    ],
+    "cautions": [
+      "Active Trader Pro can feel overwhelming",
+      "International trading requires separate applications",
+      "Cash sweep yield lags some fintech rivals"
+    ],
+    "currentPromo": "Earn up to $100 in cash credits when you deposit at least $50 within the promo window.",
+    "about": "Fidelity is a full-service brokerage that marries rock-solid customer support with low-cost investing tools. Whether you trade occasionally or manage complex retirement strategies, Fidelity's mix of research, planning, and cash management covers every life stage.",
+    "features": [
+      {
+        "name": "Active Trader Pro",
+        "description": "Desktop trading workstation with streaming quotes, ladders, and conditional orders."
+      },
+      {
+        "name": "Retirement Roadmap",
+        "description": "Interactive planning hub that models income needs, Social Security, and healthcare costs."
+      },
+      {
+        "name": "Zero Expense Ratio Funds",
+        "description": "Four index funds with 0.00% expense ratios for core equity exposure."
+      },
+      {
+        "name": "Cash Management",
+        "description": "FDIC-insured sweep program with ATM reimbursements and bill pay integration."
+      }
+    ],
+    "feesAndMinimums": {
+      "managementFee": "$0 commissions plus free Fidelity ZERO index funds",
+      "productFees": "0.00% advisory fee on Fidelity Go up to $25K (0.35% above)",
+      "accountMinimum": "$0 for standard brokerage; $10 for Fidelity Go",
+      "accountTypes": "Individual & joint taxable, Traditional/Roth/SEP IRA, 401(k) rollovers, HSAs"
+    },
+    "prosCons": {
+      "pros": [
+        "Research depth rivals institutional desks",
+        "Industry-leading customer satisfaction and NPS",
+        "Comprehensive retirement and college planning resources"
+      ],
+      "cons": [
+        "Advanced tools have steeper learning curve",
+        "International trading access is limited",
+        "Cash sweep yields trail high-yield fintech accounts"
+      ]
+    },
     "score": {
       "vertical": "broker",
       "breakdown": {
@@ -91,12 +262,22 @@
         "features": 89,
         "platform": 87,
         "support": 91
+      },
+      "deepDive": {
+        "transparency": { "weight": 0.22, "score": 94 },
+        "cost": { "weight": 0.18, "score": 96 },
+        "features": { "weight": 0.25, "score": 92 },
+        "support": { "weight": 0.2, "score": 95 },
+        "returns": { "weight": 0.15, "score": 88 }
       }
     },
+    "finalVerdict": "Fidelity is the gold-standard pick for investors who want deep planning support with low fees. The welcome bonus is modest, but the long-term value comes from best-in-class research, customer care, and a comprehensive product shelf.",
+    "referralUrl": "https://www.fidelity.com/",
     "disclaimer": "Fidelity bonuses require maintaining qualifying assets for 90 days. Consult Fidelity's bonus terms for additional restrictions and taxable implications."
   },
   {
     "id": "sofi",
+    "slug": "sofi",
     "name": "SoFi Invest",
     "headline": "Get up to $1,000 in stock when you transfer or deposit funds into SoFi Active Invest",
     "summary": "SoFi Invest rewards new clients with a tiered stock bonus and bundles access to financial planners, cash management, and crypto trading in one app.",
@@ -116,6 +297,56 @@
       "Integrated banking with up to 4.60% APY savings"
     ],
     "idealFor": ["Hybrid investors", "Holistic financial planning"],
+    "logo": "https://logo.clearbit.com/sofi.com",
+    "bestFor": ["Hands-off investors", "Members seeking bundled banking and investing"],
+    "strengths": [
+      "Automated portfolios with zero management fees",
+      "Access to CFP® professionals for goal planning",
+      "Integrated ecosystem spanning loans, banking, and investing"
+    ],
+    "cautions": [
+      "Limited advanced trading features",
+      "ETF lineup leans heavily on proprietary funds",
+      "Phone support restricted to business hours"
+    ],
+    "currentPromo": "Transfer or deposit $100–$100,000 to receive $25 – $1,000 in bonus stock.",
+    "about": "SoFi Invest packages automated portfolios, active investing, and crypto trading into a single, member-centric platform. The app ties seamlessly into SoFi's banking and lending products, rewarding loyal customers with rate discounts and financial coaching.",
+    "features": [
+      {
+        "name": "Automated Investing",
+        "description": "Goal-based portfolios with automatic rebalancing and dividend reinvestment at no advisory fee."
+      },
+      {
+        "name": "Member Financial Planning",
+        "description": "Complimentary sessions with CFP® professionals to map milestones like weddings, college, and retirement."
+      },
+      {
+        "name": "Integrated Banking",
+        "description": "High-yield savings up to 4.60% APY plus direct deposit perks that flow into investing goals."
+      },
+      {
+        "name": "Active & Crypto Trading",
+        "description": "Buy individual stocks, ETFs, and select cryptocurrencies inside the same streamlined app."
+      }
+    ],
+    "feesAndMinimums": {
+      "managementFee": "0.00% advisory fee on automated portfolios",
+      "productFees": "0.19% – 0.29% blended expense ratios on SoFi ETFs",
+      "accountMinimum": "$0 for automated investing; $10 for active investing",
+      "accountTypes": "Taxable brokerage, Traditional & Roth IRA, SEP IRA"
+    },
+    "prosCons": {
+      "pros": [
+        "Holistic money management inside one membership",
+        "Access to human advisors without extra cost",
+        "Strong cash bonuses for high deposit tiers"
+      ],
+      "cons": [
+        "Trading tools trail specialist brokerages",
+        "ETF lineup leans on proprietary strategies",
+        "Crypto offering limited versus dedicated exchanges"
+      ]
+    },
     "score": {
       "vertical": "broker",
       "breakdown": {
@@ -123,8 +354,17 @@
         "features": 80,
         "platform": 83,
         "support": 78
+      },
+      "deepDive": {
+        "transparency": { "weight": 0.2, "score": 82 },
+        "cost": { "weight": 0.2, "score": 88 },
+        "features": { "weight": 0.23, "score": 84 },
+        "support": { "weight": 0.22, "score": 80 },
+        "returns": { "weight": 0.15, "score": 76 }
       }
     },
+    "finalVerdict": "SoFi Invest shines for members who want automated portfolios, human guidance, and high-yield banking under one login. It is less compelling for pro traders, but the all-in-one ecosystem and upfront stock bonus make it a standout for long-term planners.",
+    "referralUrl": "https://www.sofi.com/invest/",
     "disclaimer": "Bonuses are paid in SoFi stock bits and may be rescinded if account balances fall below tier minimums. Review SoFi's promotional terms for the latest criteria."
   }
 ]

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import App from "./App.jsx";
 import Offers from "./pages/offers.jsx";
+import BrokerDeepDivePage from "./pages/broker/[slug].jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
@@ -11,6 +12,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/offers" element={<Offers />} />
+        <Route path="/broker/:slug" element={<BrokerDeepDivePage />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>

--- a/src/pages/broker/[slug].jsx
+++ b/src/pages/broker/[slug].jsx
@@ -1,0 +1,443 @@
+import React, { useEffect, useMemo } from "react";
+import { Link, useParams } from "react-router-dom";
+import ScoreBadge from "../../components/score/ScoreBadge";
+import brokers from "../../data/brokers.json";
+
+function computeAverageScore(breakdown = {}) {
+  const values = Object.values(breakdown)
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const total = values.reduce((sum, current) => sum + current, 0);
+  return Math.round(total / values.length);
+}
+
+function formatWeight(weight) {
+  if (!Number.isFinite(weight)) {
+    return "—";
+  }
+
+  return `${Math.round(weight * 100)}%`;
+}
+
+export default function BrokerDeepDivePage() {
+  const { slug } = useParams();
+
+  const broker = useMemo(
+    () => brokers.find((entry) => (entry.slug ?? entry.id) === slug),
+    [slug]
+  );
+
+  const averageScore = useMemo(
+    () => computeAverageScore(broker?.score?.breakdown ?? {}),
+    [broker]
+  );
+
+  const deepDiveEntries = useMemo(() => {
+    const entries = Object.entries(broker?.score?.deepDive ?? {});
+    return entries.map(([key, value]) => ({
+      key,
+      label: key.charAt(0).toUpperCase() + key.slice(1),
+      weight: Number(value?.weight ?? 0),
+      score: Number(value?.score ?? 0),
+    }));
+  }, [broker]);
+
+  const weightedTotal = useMemo(
+    () =>
+      deepDiveEntries.reduce(
+        (sum, entry) => sum + entry.weight * entry.score,
+        0
+      ),
+    [deepDiveEntries]
+  );
+
+  const weightedScore = Math.round(weightedTotal);
+  const heroScore = deepDiveEntries.length > 0 ? weightedScore : averageScore;
+
+  const pageTitle = broker
+    ? `${broker.name} Review (2025) – MyFreeStocks Deep-Dive Score™ Analysis`
+    : "Broker Review Not Found – MyFreeStocks";
+
+  const metaDescription = broker
+    ? `${broker.summary} Dive into the full MyFreeStock Score™ breakdown, fees, and editorial verdict for ${broker.name}.`
+    : "We couldn't find the broker deep-dive review you were searching for on MyFreeStocks.";
+
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = pageTitle;
+
+    let descriptionTag = document.querySelector('meta[name="description"]');
+    const createdTag = !descriptionTag;
+
+    if (!descriptionTag) {
+      descriptionTag = document.createElement("meta");
+      descriptionTag.setAttribute("name", "description");
+      document.head.appendChild(descriptionTag);
+    }
+
+    const previousDescription = descriptionTag.getAttribute("content");
+    descriptionTag.setAttribute("content", metaDescription);
+
+    return () => {
+      document.title = previousTitle;
+      if (createdTag) {
+        descriptionTag?.remove();
+      } else if (previousDescription !== null) {
+        descriptionTag.setAttribute("content", previousDescription);
+      } else {
+        descriptionTag.removeAttribute("content");
+      }
+    };
+  }, [pageTitle, metaDescription]);
+
+  if (!broker) {
+    return (
+      <div className="min-h-screen bg-[#050B1A] text-slate-100">
+        <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-4 text-center">
+          <Link
+            to="/offers"
+            className="mb-6 inline-flex items-center gap-2 text-sm font-semibold text-emerald-300 transition hover:text-emerald-200"
+          >
+            <span aria-hidden>←</span> Back to Offers
+          </Link>
+          <div className="space-y-4 rounded-3xl border border-white/5 bg-[#0B1622] p-10 shadow-[0_30px_80px_-60px_rgba(16,185,129,0.5)]">
+            <h1 className="text-3xl font-semibold text-white">Broker deep dive not found</h1>
+            <p className="text-sm text-slate-300">
+              We couldn't locate the review you're after. Please return to the offers page to explore the latest verified promotions.
+            </p>
+            <Link
+              to="/offers"
+              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+            >
+              View current offers
+            </Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const {
+    name,
+    logo,
+    summary,
+    about,
+    bestFor = [],
+    strengths = [],
+    cautions = [],
+    currentPromo,
+    features = [],
+    feesAndMinimums = {},
+    prosCons = {},
+    finalVerdict,
+    referralUrl,
+    offer: offerDetails = {},
+  } = broker;
+
+  const { managementFee, productFees, accountMinimum, accountTypes } =
+    feesAndMinimums;
+
+  const derivedPromo = [offerDetails?.value, offerDetails?.requirement]
+    .filter(Boolean)
+    .join(" • ");
+
+  const heroTiles = [
+    {
+      title: "Best for",
+      content: bestFor,
+    },
+    {
+      title: "Top strengths",
+      content: strengths,
+    },
+    {
+      title: "Cautions",
+      content: cautions,
+    },
+    {
+      title: "Current promo",
+      content: currentPromo ?? derivedPromo,
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-[#050B1A] text-slate-100">
+      <main className="mx-auto max-w-6xl px-4 py-10">
+        <Link
+          to="/offers"
+          className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-300 transition hover:text-emerald-200"
+        >
+          <span aria-hidden>←</span> Back to Offers
+        </Link>
+
+        <section className="mt-6 overflow-hidden rounded-3xl border border-white/5 bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_60px_160px_-80px_rgba(16,185,129,0.75)]">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-1 items-start gap-6">
+              <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl border border-emerald-400/30 bg-white/5">
+                {logo ? (
+                  <img src={logo} alt={`${name} logo`} className="h-16 w-16 object-contain" />
+                ) : (
+                  <span className="text-2xl font-semibold text-emerald-200">
+                    {name?.charAt(0) ?? ""}
+                  </span>
+                )}
+              </div>
+              <div className="space-y-3">
+                <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                  MyFreeStock Score™ Deep Dive
+                </span>
+                <h1 className="text-4xl font-bold text-white sm:text-5xl">
+                  {name} Review (2025)
+                </h1>
+                <p className="max-w-2xl text-base text-slate-300 sm:text-lg">{summary}</p>
+              </div>
+            </div>
+            <div className="flex flex-col items-end gap-3 text-right">
+              <ScoreBadge score={heroScore} />
+              <span className="text-xs uppercase tracking-[0.35em] text-slate-400">
+                Score refreshed weekly
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {heroTiles.map((tile) => (
+              <div
+                key={tile.title}
+                className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_30px_80px_-70px_rgba(16,185,129,0.85)]"
+              >
+                <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">
+                  {tile.title}
+                </h2>
+                {(() => {
+                  if (Array.isArray(tile.content)) {
+                    const items = tile.content.filter(Boolean);
+                    if (items.length === 0) {
+                      return (
+                        <p className="mt-3 text-sm text-slate-200">—</p>
+                      );
+                    }
+
+                    return (
+                      <ul className="mt-3 space-y-2 text-sm text-slate-200">
+                        {items.map((item) => (
+                          <li key={item} className="flex items-start gap-2">
+                            <span aria-hidden className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-300" />
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    );
+                  }
+
+                  return (
+                    <p className="mt-3 text-sm text-slate-200">
+                      {tile.content ?? "—"}
+                    </p>
+                  );
+                })()}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {about && (
+          <section className="mt-12 rounded-3xl border border-white/5 bg-[#071025] p-10 shadow-[0_40px_120px_-90px_rgba(16,185,129,0.7)]">
+            <h2 className="text-2xl font-semibold text-white">About {name}</h2>
+            <p className="mt-4 text-base text-slate-300">{about}</p>
+          </section>
+        )}
+
+        {features.length > 0 && (
+          <section className="mt-12">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-2xl font-semibold text-white">Key Platform Features</h2>
+              <span className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                Deep-Dive Format
+              </span>
+            </div>
+            <div className="mt-6 overflow-hidden rounded-3xl border border-white/5 bg-[#071025] shadow-[0_40px_120px_-90px_rgba(16,185,129,0.6)]">
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-white/5 text-left">
+                  <thead className="bg-white/5">
+                    <tr>
+                      <th scope="col" className="px-6 py-4 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                        Feature
+                      </th>
+                      <th scope="col" className="px-6 py-4 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                        What it means
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-white/5">
+                    {features.map((feature) => (
+                      <tr key={feature.name} className="transition hover:bg-white/5">
+                        <td className="align-top px-6 py-5 text-sm font-semibold text-white">
+                          {feature.name}
+                        </td>
+                        <td className="px-6 py-5 text-sm text-slate-300">
+                          {feature.description}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section className="mt-12 grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="rounded-3xl border border-white/5 bg-[#071025] p-8 shadow-[0_40px_120px_-90px_rgba(16,185,129,0.6)]">
+            <h2 className="text-2xl font-semibold text-white">Fees & Minimums</h2>
+            <dl className="mt-6 space-y-4 text-sm text-slate-200">
+              {managementFee && (
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                    Management fee
+                  </dt>
+                  <dd className="mt-1 text-base text-white">{managementFee}</dd>
+                </div>
+              )}
+              {productFees && (
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                    Product fees
+                  </dt>
+                  <dd className="mt-1 text-base text-white">{productFees}</dd>
+                </div>
+              )}
+              {accountMinimum && (
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                    Minimum to start
+                  </dt>
+                  <dd className="mt-1 text-base text-white">{accountMinimum}</dd>
+                </div>
+              )}
+              {accountTypes && (
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                    Account types
+                  </dt>
+                  <dd className="mt-1 text-base text-white">{accountTypes}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          <div className="rounded-3xl border border-white/5 bg-[#071025] p-8 shadow-[0_40px_120px_-90px_rgba(16,185,129,0.6)]">
+            <h2 className="text-2xl font-semibold text-white">Pros & Cons</h2>
+            <div className="mt-6 grid gap-6 md:grid-cols-2">
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                  Pros
+                </h3>
+                <ul className="mt-3 space-y-2 text-sm text-slate-200">
+                  {(prosCons.pros ?? []).map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span aria-hidden className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-300" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                  Cons
+                </h3>
+                <ul className="mt-3 space-y-2 text-sm text-slate-200">
+                  {(prosCons.cons ?? []).map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span aria-hidden className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-300" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {deepDiveEntries.length > 0 && (
+          <section className="mt-12 rounded-3xl border border-white/5 bg-[#071025] p-10 shadow-[0_40px_120px_-90px_rgba(16,185,129,0.7)]">
+            <h2 className="text-2xl font-semibold text-white">MyFreeStock Score™ Breakdown</h2>
+            <p className="mt-2 text-sm text-slate-300">
+              Weightings are set by the MyFreeStock research desk to balance transparency, cost, platform experience, support quality, and realized returns.
+            </p>
+            <div className="mt-6 overflow-x-auto">
+              <table className="min-w-full divide-y divide-white/5 text-left">
+                <thead className="bg-white/5">
+                  <tr>
+                    <th scope="col" className="px-6 py-4 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                      Pillar
+                    </th>
+                    <th scope="col" className="px-6 py-4 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                      Weight
+                    </th>
+                    <th scope="col" className="px-6 py-4 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                      Score
+                    </th>
+                    <th scope="col" className="px-6 py-4 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                      Weight × Score
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5">
+                  {deepDiveEntries.map((entry) => (
+                    <tr key={entry.key} className="transition hover:bg-white/5">
+                      <td className="px-6 py-5 text-sm font-semibold text-white">
+                        {entry.label}
+                      </td>
+                      <td className="px-6 py-5 text-sm text-slate-300">
+                        {formatWeight(entry.weight)}
+                      </td>
+                      <td className="px-6 py-5 text-sm text-slate-300">
+                        {entry.score}
+                      </td>
+                      <td className="px-6 py-5 text-sm text-slate-300">
+                        {(entry.weight * entry.score).toFixed(1)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot className="bg-white/5">
+                  <tr>
+                    <th scope="row" className="px-6 py-4 text-sm font-semibold text-white">
+                      Composite (Σ weight × score)
+                    </th>
+                    <td className="px-6 py-4 text-sm text-slate-300">100%</td>
+                    <td className="px-6 py-4 text-sm text-slate-300">{heroScore}</td>
+                    <td className="px-6 py-4 text-sm text-slate-300">{weightedTotal.toFixed(1)}</td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </section>
+        )}
+
+        <section className="mt-12 rounded-3xl border border-emerald-400/20 bg-gradient-to-br from-emerald-500/10 via-emerald-500/5 to-transparent p-10 shadow-[0_50px_140px_-80px_rgba(16,185,129,0.75)]">
+          <div className="space-y-5">
+            <h2 className="text-3xl font-semibold text-white">Final Verdict</h2>
+            {finalVerdict && (
+              <p className="text-base text-slate-100">{finalVerdict}</p>
+            )}
+            <a
+              href={referralUrl ?? broker.cta?.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-8 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-emerald-500/40 transition hover:brightness-110 sm:w-auto"
+            >
+              Claim Offer
+            </a>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/offers.jsx
+++ b/src/pages/offers.jsx
@@ -385,6 +385,7 @@ export default function OffersPage() {
                     scoreOverride={offer.computedScore}
                     variant="dark"
                     className="bg-[#0A152E]/60"
+                    slug={offer.slug ?? offer.id}
                   />
                 </div>
 


### PR DESCRIPTION
## Summary
- add a dynamic `/broker/:slug` page that renders editorial-style deep dive reviews with SEO metadata and CTA routing
- expand the brokers dataset with hero content, feature tables, pros/cons, and deep-dive score weights powering the new layout
- update score cards and offers listings to link directly into the detailed broker review experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fe78944483328cdf2e885b6dc335