### PR TITLE
feat: add MyFreeStock Score™ ticker section (binary assets skipped for manual upload)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>myfreestocks</title>
   </head>

--- a/src/components/score/ScoreTicker.jsx
+++ b/src/components/score/ScoreTicker.jsx
@@ -1,0 +1,188 @@
+import React, { useMemo, useState } from "react";
+
+function formatPercent(change, prev) {
+  if (!Number.isFinite(change) || !Number.isFinite(prev) || prev === 0) {
+    return "0.0%";
+  }
+
+  const percent = (change / prev) * 100;
+  const rounded = Math.abs(percent).toFixed(1);
+  if (percent > 0) {
+    return `+${rounded}%`;
+  }
+  if (percent < 0) {
+    return `−${rounded}%`;
+  }
+  return "0.0%";
+}
+
+export default function ScoreTicker({ brokers = [] }) {
+  const [isPaused, setIsPaused] = useState(false);
+
+  const items = useMemo(() => {
+    return brokers
+      .filter((broker) => broker?.score)
+      .map((broker) => {
+        const history = Array.isArray(broker.scoreHistory)
+          ? broker.scoreHistory
+          : [];
+
+        const currentEntry = history[history.length - 1];
+        const previousEntry = history[history.length - 2];
+
+        const currentScore = Number.isFinite(currentEntry?.score)
+          ? Number(currentEntry.score)
+          : Number(broker.score?.overall ?? broker.computedScore);
+
+        if (!Number.isFinite(currentScore)) {
+          return null;
+        }
+
+        const previousScore = Number.isFinite(previousEntry?.score)
+          ? Number(previousEntry.score)
+          : undefined;
+
+        const change =
+          Number.isFinite(previousScore) && previousScore !== undefined
+            ? currentScore - previousScore
+            : 0;
+
+        let direction = "flat";
+        if (change > 0) direction = "up";
+        if (change < 0) direction = "down";
+
+        return {
+          id: broker.id ?? broker.slug ?? broker.name,
+          name: broker.name,
+          currentScore,
+          change,
+          previousScore,
+          direction,
+        };
+      })
+      .filter(Boolean);
+  }, [brokers]);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const tickerClassNames = [
+    "score-ticker--track flex w-max items-center gap-6 whitespace-nowrap animate-[score-ticker-scroll_44s_linear_infinite]",
+    isPaused ? "[animation-play-state:paused]" : "",
+  ]
+    .join(" ")
+    .trim();
+
+  const renderItems = (suffix) =>
+    items.map((item, index) => {
+      const indicatorClasses =
+        item.direction === "up"
+          ? "text-emerald-300"
+          : item.direction === "down"
+            ? "text-rose-400"
+            : "text-slate-400";
+
+      const glowClasses =
+        item.direction === "up"
+          ? "shadow-[0_0_18px_rgba(16,185,129,0.35)] animate-[score-ticker-glow_2.3s_ease-in-out_infinite]"
+          : "";
+
+      const symbol =
+        item.direction === "up"
+          ? "▲"
+          : item.direction === "down"
+            ? "▼"
+            : "▬";
+
+      return (
+        <div
+          key={`${item.id}-${suffix}-${index}`}
+          className={`relative flex items-center gap-3 after:mx-4 after:text-slate-600/70 after:content-['•'] last:after:hidden`}
+        >
+          <div
+            className={`flex items-center gap-2 rounded-2xl border border-white/5 bg-white/5 px-3 py-1 text-sm font-medium text-white shadow-inner ${glowClasses}`}
+          >
+            <span className="font-semibold text-white/90">{item.name}</span>
+            <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-200">
+              {item.currentScore}
+            </span>
+            <span className={`flex items-center gap-1 text-xs font-semibold ${indicatorClasses}`}>
+              <span aria-hidden>{symbol}</span>
+              <span>{formatPercent(item.change, item.previousScore)}</span>
+            </span>
+          </div>
+        </div>
+      );
+    });
+
+  const handlePause = () => setIsPaused(true);
+  const handleResume = () => setIsPaused(false);
+
+  return (
+    <section
+      className="border-b border-emerald-500/10 bg-[#071026]"
+      aria-label="MyFreeStock Score ticker"
+    >
+      <style>{`
+        @keyframes score-ticker-scroll {
+          0% { transform: translateX(0); }
+          100% { transform: translateX(-50%); }
+        }
+        @keyframes score-ticker-glow {
+          0%, 100% { box-shadow: 0 0 0 rgba(16, 185, 129, 0.15); }
+          50% { box-shadow: 0 0 18px rgba(16, 185, 129, 0.35); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .score-ticker--track {
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1 !important;
+            transform: translateX(0) !important;
+          }
+        }
+      `}</style>
+      <div className="mx-auto flex max-w-6xl items-center gap-4 px-4 py-3">
+        <div className="flex w-full shrink-0 items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-emerald-200 sm:w-auto sm:justify-start sm:text-xs sm:tracking-[0.35em]">
+          <span className="flex items-baseline gap-1 whitespace-nowrap">
+            <span>MyFreeStock Score</span>
+            <span className="text-[0.55rem] align-super text-emerald-100">™</span>
+            <span className="tracking-[0.2em] text-emerald-100 sm:tracking-[0.35em]">Live</span>
+          </span>
+        </div>
+        <div className="group/ticker relative hidden flex-1 overflow-hidden sm:flex">
+          <div
+            className="absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-[#071026] via-[#071026]/70 to-transparent"
+            aria-hidden
+          />
+          <div
+            className="absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-[#071026] via-[#071026]/70 to-transparent"
+            aria-hidden
+          />
+          <div
+            className="relative flex w-full items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60"
+            onMouseEnter={handlePause}
+            onMouseLeave={handleResume}
+            onTouchStart={handlePause}
+            onTouchEnd={handleResume}
+            onTouchCancel={handleResume}
+            onFocus={handlePause}
+            onBlur={handleResume}
+            tabIndex={0}
+            aria-label="Live MyFreeStock Score updates"
+          >
+            <div className={tickerClassNames}>
+              {renderItems("a")}
+              {renderItems("b")}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="px-4 pb-3 sm:hidden">
+        <p className="rounded-2xl border border-emerald-400/10 bg-white/5 px-4 py-2 text-[0.7rem] text-emerald-200">
+          Scores refresh weekly from broker data feeds.
+          {/* TODO: Connect to live score streaming API when available */}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/data/brokers.json
+++ b/src/data/brokers.json
@@ -91,6 +91,11 @@
         "returns": { "weight": 0.15, "score": 78 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-08-15", "score": 81 },
+      { "date": "2025-09-15", "score": 83 },
+      { "date": "2025-10-15", "score": 84 }
+    ],
     "finalVerdict": "Robinhood is ideal for new and mobile-first investors who prize simplicity and no-commission trading, but data-heavy traders may need more robust research tools.",
     "referralUrl": "https://robinhood.com/",
     "disclaimer": "Promotional stock value varies with market price. Terms and eligibility apply."
@@ -187,6 +192,11 @@
         "returns": { "weight": 0.15, "score": 82 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-08-15", "score": 88 },
+      { "date": "2025-09-15", "score": 88 },
+      { "date": "2025-10-15", "score": 88 }
+    ],
     "finalVerdict": "Webull is a standout for active traders who want deep analytics and extended-hours access without platform fees, though newcomers may prefer a gentler interface.",
     "referralUrl": "https://www.webull.com/",
     "disclaimer": "Stock reward value varies by draw. Promotional terms from Webull apply."
@@ -283,6 +293,10 @@
         "returns": { "weight": 0.15, "score": 80 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-09-15", "score": 87 },
+      { "date": "2025-10-15", "score": 86 }
+    ],
     "finalVerdict": "Moomoo excels for globally minded traders who want deep market data without paying platform subscriptions, though the dense interface can challenge newcomers.",
     "referralUrl": "https://www.moomoo.com/",
     "disclaimer": "Promotional stock awards depend on deposit size and campaign timing. Review Moomoo terms."
@@ -379,6 +393,10 @@
         "returns": { "weight": 0.15, "score": 88 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-09-15", "score": 88 },
+      { "date": "2025-10-15", "score": 89 }
+    ],
     "finalVerdict": "SoFi Invest is best for members who want banking, lending, and investing in one app with automated portfolios and advisor access, though active traders may crave more advanced tools.",
     "referralUrl": "https://www.sofi.com/invest/",
     "disclaimer": "Bonus stock value depends on deposit tiers and holding requirements. Review SoFi's promotional terms."
@@ -475,6 +493,10 @@
         "returns": { "weight": 0.15, "score": 89 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-09-15", "score": 89 },
+      { "date": "2025-10-15", "score": 90 }
+    ],
     "finalVerdict": "Wealthfront remains a leader for automated investing with sophisticated tax management and a seamless cash experience, though investors needing live advisors should look elsewhere.",
     "referralUrl": "https://www.wealthfront.com/",
     "disclaimer": "Fee waiver applies to new customers and may require referral link activation."
@@ -571,6 +593,10 @@
         "returns": { "weight": 0.15, "score": 87 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-09-15", "score": 87 },
+      { "date": "2025-10-15", "score": 88 }
+    ],
     "finalVerdict": "Betterment is an excellent long-term partner for investors who want automated portfolios, cash tools, and clear goal tracking without managing individual securities.",
     "referralUrl": "https://www.betterment.com/",
     "disclaimer": "Promotional fee waivers vary by deposit size and timeframe."
@@ -665,6 +691,10 @@
         "returns": { "weight": 0.15, "score": 90 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-09-15", "score": 92 },
+      { "date": "2025-10-15", "score": 93 }
+    ],
     "finalVerdict": "Fidelity is the gold standard for investors who want sophisticated research, retirement planning, and broad investment choice backed by stellar service.",
     "referralUrl": "https://www.fidelity.com/",
     "disclaimer": "Bonuses vary by promotion and require maintaining assets for eligibility."
@@ -759,6 +789,10 @@
         "returns": { "weight": 0.15, "score": 88 }
       }
     },
+    "scoreHistory": [
+      { "date": "2025-09-15", "score": 92 },
+      { "date": "2025-10-15", "score": 91 }
+    ],
     "finalVerdict": "Charles Schwab is a balanced choice for investors who value strong service, broad product access, and low-cost index investing, even if the interface feels more traditional.",
     "referralUrl": "https://www.schwab.com/",
     "disclaimer": "Bonus eligibility depends on net new assets maintained for the promotional period."

--- a/src/pages/offers.jsx
+++ b/src/pages/offers.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import ScoreCard from "../components/score/ScoreCard";
 import ScoreBadge from "../components/score/ScoreBadge";
+import ScoreTicker from "../components/score/ScoreTicker";
 import useBrokerData from "../hooks/useBrokerData";
 
 function computeScore(breakdown = {}) {
@@ -213,6 +214,8 @@ export default function OffersPage() {
           </nav>
         </div>
       </header>
+
+      <ScoreTicker brokers={brokerData} />
 
       <main className="mx-auto max-w-6xl px-4">
         <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)]">


### PR DESCRIPTION
## Summary
- add a branded MyFreeStock Score™ ticker component and surface it on the offers page beneath the header
- enrich broker seed data with score history entries so the ticker can highlight direction and percent changes
- refresh the favicon link tags in the document head so the new branded icons (to be uploaded manually) render across devices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e419e02a508332a1523be55cc429bd