### PR TITLE
Ensure mobile navigation matches desktop links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
+import navLinks from "./components/layout/navLinks";
 
 const tickerItems = [
   { symbol: "AAPL", change: "+1.24%" },
@@ -123,21 +124,35 @@ export default function App() {
             <img src="/logo-dark.svg" alt="MyFreeStocks.com" className="h-9 w-auto" />
           </div>
           <nav className="hidden items-center gap-6 text-sm font-medium text-slate-200 md:flex">
-            <a href="/offers" className={getDesktopNavClass("/offers")}>
-              Offers
-            </a>
-            <NavLink
-              to="/how-it-works"
-              className={getDesktopNavClass("/how-it-works", { highlight: false })}
-            >
-              How It Works
-            </NavLink>
-            <a href="/robo-advisors" className={getDesktopNavClass("/robo-advisors")}>
-              AI Robo-Advisors
-            </a>
-            <a href="#contact" className={getDesktopNavClass("/", { highlight: false })}>
-              Contact
-            </a>
+            {navLinks.map((item) => {
+              if (item.href) {
+                const targetPath = item.href.startsWith("/#") ? "/" : item.href;
+
+                return (
+                  <a
+                    key={item.label}
+                    href={item.href}
+                    className={getDesktopNavClass(targetPath, {
+                      highlight: item.highlight !== false,
+                    })}
+                  >
+                    {item.label}
+                  </a>
+                );
+              }
+
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={getDesktopNavClass(item.to, {
+                    highlight: item.highlight !== false,
+                  })}
+                >
+                  {item.label}
+                </NavLink>
+              );
+            })}
           </nav>
           <a
             href="/offers"
@@ -178,32 +193,43 @@ export default function App() {
           }`}
         >
           <nav className="flex flex-col gap-2 px-4 py-4 text-sm font-semibold">
-            <a href="#top" onClick={handleCloseMenu} className={getMobileNavClass("/")}>
-              Home
-            </a>
-            <a href="/offers" onClick={handleCloseMenu} className={getMobileNavClass("/offers")}>
-              Offers
-            </a>
-            <a
-              href="#compare"
-              onClick={handleCloseMenu}
-              className={getMobileNavClass("/", { highlight: false })}
-            >
-              Compare
-            </a>
-            <a
-              href="/robo-advisors"
-              onClick={handleCloseMenu}
-              className={getMobileNavClass("/robo-advisors")}
-            >
-              Robo-Advisors
-            </a>
+            {navLinks.map((item) => {
+              const baseClasses = "rounded-lg px-3 py-2 transition hover:bg-white/10";
+
+              if (item.href) {
+                return (
+                  <a
+                    key={item.label}
+                    href={item.href}
+                    onClick={handleCloseMenu}
+                    className={`${baseClasses} text-white`}
+                  >
+                    {item.label}
+                  </a>
+                );
+              }
+
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  onClick={handleCloseMenu}
+                  className={({ isActive }) =>
+                    `${baseClasses} ${
+                      isActive ? "bg-white/10 text-emerald-200" : "text-white"
+                    }`
+                  }
+                >
+                  {item.label}
+                </NavLink>
+              );
+            })}
             <a
               href="/offers"
               onClick={handleCloseMenu}
               className="mt-2 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
             >
-              See Offers
+              Compare Offers
             </a>
           </nav>
         </div>

--- a/src/components/layout/PageShell.jsx
+++ b/src/components/layout/PageShell.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Link, NavLink } from "react-router-dom";
+import navLinks from "./navLinks";
 
 const tickerItems = [
   { symbol: "AAPL", change: "+1.24%" },
@@ -33,19 +34,34 @@ export default function PageShell({ children, mainClassName = "" }) {
             <img src="/logo-dark.svg" alt="MyFreeStocks.com" className="h-9 w-auto" />
           </Link>
 
-          <nav className="hidden items-center gap-6 text-sm font-medium text-slate-200 md:flex">
-            <Link to="/offers" className="transition hover:text-emerald-300">
-              Offers
-            </Link>
-            <NavLink to="/how-it-works" className="transition hover:text-emerald-300">
-              How It Works
-            </NavLink>
-            <NavLink to="/robo-advisors" className="transition hover:text-emerald-300">
-              AI Robo-Advisors
-            </NavLink>
-            <a href="/#contact" className="transition hover:text-emerald-300">
-              Contact
-            </a>
+          <nav className="hidden items-center gap-6 text-sm font-medium md:flex">
+            {navLinks.map((item) => {
+              if (item.href) {
+                return (
+                  <a
+                    key={item.label}
+                    href={item.href}
+                    className="transition text-slate-200 hover:text-emerald-300"
+                  >
+                    {item.label}
+                  </a>
+                );
+              }
+
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={({ isActive }) =>
+                    `transition hover:text-emerald-300 ${
+                      isActive ? "text-emerald-300" : "text-slate-200"
+                    }`
+                  }
+                >
+                  {item.label}
+                </NavLink>
+              );
+            })}
           </nav>
 
           <Link
@@ -89,32 +105,43 @@ export default function PageShell({ children, mainClassName = "" }) {
           }`}
         >
           <nav className="flex flex-col gap-2 px-4 py-4 text-sm font-semibold">
-            <Link to="/" onClick={handleCloseMenu} className="rounded-lg px-3 py-2 transition hover:bg-white/10">
-              Home
-            </Link>
-            <Link to="/offers" onClick={handleCloseMenu} className="rounded-lg px-3 py-2 transition hover:bg-white/10">
-              Offers
-            </Link>
-            <a
-              href="/#compare"
-              onClick={handleCloseMenu}
-              className="rounded-lg px-3 py-2 transition hover:bg-white/10"
-            >
-              Compare
-            </a>
-            <Link
-              to="/robo-advisors"
-              onClick={handleCloseMenu}
-              className="rounded-lg px-3 py-2 transition hover:bg-white/10"
-            >
-              Robo-Advisors
-            </Link>
+            {navLinks.map((item) => {
+              const baseClasses = "rounded-lg px-3 py-2 transition hover:bg-white/10";
+
+              if (item.href) {
+                return (
+                  <a
+                    key={item.label}
+                    href={item.href}
+                    onClick={handleCloseMenu}
+                    className={`${baseClasses} text-white`}
+                  >
+                    {item.label}
+                  </a>
+                );
+              }
+
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  onClick={handleCloseMenu}
+                  className={({ isActive }) =>
+                    `${baseClasses} ${
+                      isActive ? "bg-white/10 text-emerald-200" : "text-white"
+                    }`
+                  }
+                >
+                  {item.label}
+                </NavLink>
+              );
+            })}
             <Link
               to="/offers"
               onClick={handleCloseMenu}
               className="mt-2 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
             >
-              See Offers
+              Compare Offers
             </Link>
           </nav>
         </div>

--- a/src/components/layout/navLinks.js
+++ b/src/components/layout/navLinks.js
@@ -1,0 +1,8 @@
+export const navLinks = [
+  { label: "Offers", to: "/offers" },
+  { label: "How It Works", to: "/how-it-works" },
+  { label: "AI Robo-Advisors", to: "/robo-advisors" },
+  { label: "Contact", href: "/#contact", highlight: false },
+];
+
+export default navLinks;


### PR DESCRIPTION
## Summary
- centralize the primary navigation destinations in a shared configuration
- update the home page header to reuse the shared links on desktop and mobile, aligning the CTA copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e86f0ad6788332b6dbd7d043bf172d