### PR TITLE
refactor: finalize layout normalization and remove redundant header/footer markup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,16 @@ This file defines the roles, behaviors, and scopes for all automation and AI-ass
 
 ### ⚡ Codex Execution Directives
 
-**Primary Agent:** `builder`  
-**Fallback Agent:** `data`  
+**Primary Agent:** `builder`
+**Fallback Agent:** `data`
+
+#### Builder Agent
+
+### Layout Policy
+All new pages must import and render their content inside `<Layout>` from `@/components/layout/Layout`.    
+Do not recreate header, nav, or footer markup manually.    
+Use `<Navbar>` and `<Footer>` only inside the shared layout.    
+If older pages still reference `<PageShell>`, treat it as an alias of `<Layout>` for backward compatibility.  
 
 Codex should interpret this repository as a **React + Vite web application** and apply the following rules during execution:
 

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,13 +1,23 @@
-import React from "react";
+import React, { createContext, useContext } from "react";
 import Header from "./Header";
 import Footer from "./Footer";
 
+const LayoutContext = createContext(false);
+
 export default function Layout({ children }) {
+  const isNested = useContext(LayoutContext);
+
+  if (isNested) {
+    return <>{children}</>;
+  }
+
   return (
-    <div className="min-h-screen flex flex-col bg-[#050B1A] text-slate-100">
-      <Header />
-      <main className="flex-1">{children}</main>
-      <Footer />
-    </div>
+    <LayoutContext.Provider value>
+      <div className="min-h-screen flex flex-col bg-[#050B1A] text-slate-100">
+        <Header />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </div>
+    </LayoutContext.Provider>
   );
 }

--- a/src/pages/RoboAdvisors.jsx
+++ b/src/pages/RoboAdvisors.jsx
@@ -1,6 +1,7 @@
 // MyFreeStocks Robo-Advisors (Next-Gen AI Investors)
 import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
+import Layout from "@/components/layout/Layout";
 import ScoreBadge from "../components/score/ScoreBadge";
 
 const aiPlatforms = [
@@ -198,226 +199,228 @@ export default function RoboAdvisors() {
   const featuredPlatform = aiPlatforms[0];
 
   return (
-    <div className="bg-[#050B1A] text-slate-100">
-      <style>{`
-        @keyframes fadeIn {
-          from { opacity: 0; transform: translateY(12px); }
-          to { opacity: 1; transform: translateY(0); }
-        }
-      `}</style>
+    <Layout>
+      <div className="bg-[#050B1A] text-slate-100">
+        <style>{`
+          @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(12px); }
+            to { opacity: 1; transform: translateY(0); }
+          }
+        `}</style>
 
-      <div className="mx-auto max-w-6xl px-4 pb-24">
-        <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)] motion-safe:animate-[fadeIn_0.8s_ease-out]">
-          <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
-            <div className="space-y-6">
-              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
-                Next-Gen AI Investors
-              </span>
-              <h1 className="text-4xl font-extrabold tracking-tight text-white sm:text-5xl lg:text-6xl">
-                Build Smarter Portfolios with AI-Powered Guidance
-              </h1>
-              <p className="text-lg text-slate-300">
-                Compare automation-first platforms blending machine learning, human oversight, and transparent pricing. Discover which AI robo-advisor aligns with your goals, risk tolerance, and preferred level of control.
-              </p>
-              <div className="flex flex-wrap items-center gap-4">
-                <Link
-                  to="/offers"
-                  className="rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/40 transition hover:scale-[1.02]"
-                >
-                  Explore Promotions
-                </Link>
-                <a
-                  href="#ai-platforms"
-                  className="rounded-full border border-emerald-400/40 px-6 py-3 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
-                >
-                  View AI Platforms
-                </a>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-[36px] border border-emerald-400/20 bg-[#0A152E] p-8 shadow-xl">
-              <div className="absolute inset-0 -translate-y-6 translate-x-6 rounded-[40px] bg-emerald-500/20 blur-3xl" />
-              <div className="relative space-y-6">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
-                    Spotlight Platform
-                  </span>
-                  <ScoreBadge score={featuredPlatform.score} subtitle="Titan Score" />
-                </div>
-                <div className="space-y-2">
-                  <p className="text-2xl font-bold text-white">{featuredPlatform.name}</p>
-                  <p className="text-sm text-slate-300">{featuredPlatform.tagline}</p>
-                </div>
-                <ul className="space-y-3 text-sm text-slate-200">
-                  {featuredPlatform.features.map((item) => (
-                    <li key={item} className="flex items-start gap-3">
-                      <span className="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400" />
-                      {item}
-                    </li>
-                  ))}
-                </ul>
-                <div className="flex flex-wrap gap-3">
-                  <a
-                    href={featuredPlatform.referral}
-                    className="inline-flex flex-1 items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+        <div className="mx-auto max-w-6xl px-4 pb-24">
+          <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)] motion-safe:animate-[fadeIn_0.8s_ease-out]">
+            <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+              <div className="space-y-6">
+                <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                  Next-Gen AI Investors
+                </span>
+                <h1 className="text-4xl font-extrabold tracking-tight text-white sm:text-5xl lg:text-6xl">
+                  Build Smarter Portfolios with AI-Powered Guidance
+                </h1>
+                <p className="text-lg text-slate-300">
+                  Compare automation-first platforms blending machine learning, human oversight, and transparent pricing. Discover which AI robo-advisor aligns with your goals, risk tolerance, and preferred level of control.
+                </p>
+                <div className="flex flex-wrap items-center gap-4">
+                  <Link
+                    to="/offers"
+                    className="rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/40 transition hover:scale-[1.02]"
                   >
-                    Open Account
-                  </a>
+                    Explore Promotions
+                  </Link>
                   <a
-                    href={featuredPlatform.review}
-                    className="inline-flex flex-1 items-center justify-center rounded-full border border-emerald-400/40 px-5 py-3 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
+                    href="#ai-platforms"
+                    className="rounded-full border border-emerald-400/40 px-6 py-3 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
                   >
-                    Read Review
+                    View AI Platforms
                   </a>
                 </div>
               </div>
-            </div>
-          </div>
-        </section>
-
-        <section id="ai-platforms" className="mt-16 space-y-10 motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.1s]">
-          <div className="flex flex-col gap-4 text-center">
-            <span className="mx-auto rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
-              AI Platform Grid
-            </span>
-            <h2 className="text-3xl font-bold text-white sm:text-4xl">Compare Emerging AI Robo-Advisors</h2>
-            <p className="mx-auto max-w-3xl text-base text-slate-300">
-              From Titan's managed strategies to Composer's no-code trading recipes, explore how each platform blends automation, customization, and global access for modern investors.
-            </p>
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            {aiPlatforms.map((platform) => (
-              <div
-                key={platform.name}
-                className="group relative flex h-full flex-col justify-between rounded-3xl border border-white/5 bg-white/5 p-6 shadow-[0_30px_80px_-60px_rgba(16,185,129,0.6)] transition hover:border-emerald-400/50 hover:shadow-emerald-500/30"
-              >
-                <div className="space-y-4">
+              <div className="relative overflow-hidden rounded-[36px] border border-emerald-400/20 bg-[#0A152E] p-8 shadow-xl">
+                <div className="absolute inset-0 -translate-y-6 translate-x-6 rounded-[40px] bg-emerald-500/20 blur-3xl" />
+                <div className="relative space-y-6">
                   <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-xl font-semibold text-white">{platform.name}</p>
-                      <p className="text-sm text-emerald-300">{platform.tagline}</p>
-                    </div>
-                    <ScoreBadge score={platform.score} className="text-xs" />
+                    <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                      Spotlight Platform
+                    </span>
+                    <ScoreBadge score={featuredPlatform.score} subtitle="Titan Score" />
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-2xl font-bold text-white">{featuredPlatform.name}</p>
+                    <p className="text-sm text-slate-300">{featuredPlatform.tagline}</p>
                   </div>
                   <ul className="space-y-3 text-sm text-slate-200">
-                    {platform.features.map((feature) => (
-                      <li key={feature} className="flex items-start gap-3">
-                        <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" />
-                        {feature}
+                    {featuredPlatform.features.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <span className="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400" />
+                        {item}
                       </li>
                     ))}
                   </ul>
-                </div>
-                <div className="mt-6 grid gap-3 sm:grid-cols-2">
-                  <a
-                    href={platform.referral}
-                    className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
-                  >
-                    Get Started
-                  </a>
-                  <a
-                    href={platform.review}
-                    className="inline-flex items-center justify-center rounded-full border border-emerald-400/40 px-4 py-2 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
-                  >
-                    Platform Review
-                  </a>
+                  <div className="flex flex-wrap gap-3">
+                    <a
+                      href={featuredPlatform.referral}
+                      className="inline-flex flex-1 items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+                    >
+                      Open Account
+                    </a>
+                    <a
+                      href={featuredPlatform.review}
+                      className="inline-flex flex-1 items-center justify-center rounded-full border border-emerald-400/40 px-5 py-3 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
+                    >
+                      Read Review
+                    </a>
+                  </div>
                 </div>
               </div>
-            ))}
-          </div>
-        </section>
+            </div>
+          </section>
 
-        <section className="mt-16 rounded-3xl border border-emerald-400/20 bg-[#071025] p-8 shadow-[0_30px_90px_-70px_rgba(16,185,129,0.6)] motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.2s]">
-          <div className="flex flex-col gap-4 text-center">
-            <span className="mx-auto rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
-              Feature Comparison
-            </span>
-            <h2 className="text-3xl font-bold text-white sm:text-4xl">Where Each Platform Excels</h2>
-            <p className="mx-auto max-w-3xl text-base text-slate-300">
-              Quickly scan automation depth, human access, and cost structure to pinpoint which robo-advisor offers the right balance of control and convenience.
-            </p>
-          </div>
-
-          <div className="mt-8 overflow-hidden rounded-2xl border border-white/10">
-            <table className="w-full table-auto text-left text-sm text-slate-200">
-              <thead className="bg-[#0B1C36] text-xs uppercase tracking-wider text-emerald-300">
-                <tr>
-                  <th className="px-6 py-4">Feature</th>
-                  <th className="px-6 py-4">Titan</th>
-                  <th className="px-6 py-4">Q.ai</th>
-                  <th className="px-6 py-4">M1</th>
-                  <th className="px-6 py-4">Composer</th>
-                </tr>
-              </thead>
-              <tbody>
-                {comparisonRows.map((row, index) => (
-                  <tr
-                    key={row.label}
-                    className={`transition hover:bg-white/5 ${index % 2 === 0 ? "bg-[#0A1326]" : "bg-[#081020]"}`}
-                  >
-                    <td className="px-6 py-4 text-base font-semibold text-white">{row.label}</td>
-                    <td className="px-6 py-4">{row.titan}</td>
-                    <td className="px-6 py-4">{row.qai}</td>
-                    <td className="px-6 py-4">{row.m1}</td>
-                    <td className="px-6 py-4">{row.composer}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-
-        <section className="mt-16 space-y-6 motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.3s]">
-          <div className="text-center">
-            <span className="mx-auto inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
-              AI Investing FAQ
-            </span>
-            <h2 className="mt-4 text-3xl font-bold text-white sm:text-4xl">Educational Insights Before You Invest</h2>
-            <p className="mx-auto mt-2 max-w-3xl text-base text-slate-300">
-              Understand how intelligent automation works, the safeguards leading platforms use, and what fees to expect compared to traditional advisors.
-            </p>
-          </div>
-
-          <div className="space-y-4">
-            {faqItems.map((item) => (
-              <details
-                key={item.question}
-                className="group rounded-2xl border border-white/10 bg-[#081223] p-6 text-left transition hover:border-emerald-400/40"
-              >
-                <summary className="flex cursor-pointer list-none items-center justify-between text-lg font-semibold text-white">
-                  {item.question}
-                  <span className="ml-4 flex h-8 w-8 items-center justify-center rounded-full border border-emerald-400/40 text-sm text-emerald-300 transition group-open:rotate-45">
-                    +
-                  </span>
-                </summary>
-                <p className="mt-4 text-sm text-slate-300">{item.answer}</p>
-              </details>
-            ))}
-          </div>
-        </section>
-
-        <section className="mt-16 overflow-hidden rounded-3xl bg-gradient-to-r from-emerald-400 via-emerald-500 to-cyan-500 p-[1px] shadow-[0_40px_120px_-70px_rgba(16,185,129,0.7)] motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.4s]">
-          <div className="flex flex-col items-start gap-6 rounded-3xl bg-[#041023] px-8 py-10 text-left sm:flex-row sm:items-center sm:justify-between">
-            <div className="space-y-2">
-              <p className="text-sm font-semibold uppercase tracking-[0.35em] text-emerald-300">
-                Ready to invest smarter?
-              </p>
-              <h3 className="text-2xl font-bold text-white sm:text-3xl">
-                Start comparing AI investing platforms now.
-              </h3>
-              <p className="text-sm text-slate-300">
-                Unlock deep-dive reviews, score breakdowns, and exclusive promotions tailored to automation-first investors.
+          <section id="ai-platforms" className="mt-16 space-y-10 motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.1s]">
+            <div className="flex flex-col gap-4 text-center">
+              <span className="mx-auto rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                AI Platform Grid
+              </span>
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">Compare Emerging AI Robo-Advisors</h2>
+              <p className="mx-auto max-w-3xl text-base text-slate-300">
+                From Titan's managed strategies to Composer's no-code trading recipes, explore how each platform blends automation, customization, and global access for modern investors.
               </p>
             </div>
-            <Link
-              to="/offers"
-              className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#041023] shadow-lg transition hover:brightness-110"
-            >
-              Compare Offers
-            </Link>
-          </div>
-        </section>
+
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {aiPlatforms.map((platform) => (
+                <div
+                  key={platform.name}
+                  className="group relative flex h-full flex-col justify-between rounded-3xl border border-white/5 bg-white/5 p-6 shadow-[0_30px_80px_-60px_rgba(16,185,129,0.6)] transition hover:border-emerald-400/50 hover:shadow-emerald-500/30"
+                >
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-xl font-semibold text-white">{platform.name}</p>
+                        <p className="text-sm text-emerald-300">{platform.tagline}</p>
+                      </div>
+                      <ScoreBadge score={platform.score} className="text-xs" />
+                    </div>
+                    <ul className="space-y-3 text-sm text-slate-200">
+                      {platform.features.map((feature) => (
+                        <li key={feature} className="flex items-start gap-3">
+                          <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" />
+                          {feature}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                    <a
+                      href={platform.referral}
+                      className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+                    >
+                      Get Started
+                    </a>
+                    <a
+                      href={platform.review}
+                      className="inline-flex items-center justify-center rounded-full border border-emerald-400/40 px-4 py-2 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
+                    >
+                      Platform Review
+                    </a>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="mt-16 rounded-3xl border border-emerald-400/20 bg-[#071025] p-8 shadow-[0_30px_90px_-70px_rgba(16,185,129,0.6)] motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.2s]">
+            <div className="flex flex-col gap-4 text-center">
+              <span className="mx-auto rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                Feature Comparison
+              </span>
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">Where Each Platform Excels</h2>
+              <p className="mx-auto max-w-3xl text-base text-slate-300">
+                Quickly scan automation depth, human access, and cost structure to pinpoint which robo-advisor offers the right balance of control and convenience.
+              </p>
+            </div>
+
+            <div className="mt-8 overflow-hidden rounded-2xl border border-white/10">
+              <table className="w-full table-auto text-left text-sm text-slate-200">
+                <thead className="bg-[#0B1C36] text-xs uppercase tracking-wider text-emerald-300">
+                  <tr>
+                    <th className="px-6 py-4">Feature</th>
+                    <th className="px-6 py-4">Titan</th>
+                    <th className="px-6 py-4">Q.ai</th>
+                    <th className="px-6 py-4">M1</th>
+                    <th className="px-6 py-4">Composer</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {comparisonRows.map((row, index) => (
+                    <tr
+                      key={row.label}
+                      className={`transition hover:bg-white/5 ${index % 2 === 0 ? "bg-[#0A1326]" : "bg-[#081020]"}`}
+                    >
+                      <td className="px-6 py-4 text-base font-semibold text-white">{row.label}</td>
+                      <td className="px-6 py-4">{row.titan}</td>
+                      <td className="px-6 py-4">{row.qai}</td>
+                      <td className="px-6 py-4">{row.m1}</td>
+                      <td className="px-6 py-4">{row.composer}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="mt-16 space-y-6 motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.3s]">
+            <div className="text-center">
+              <span className="mx-auto inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                AI Investing FAQ
+              </span>
+              <h2 className="mt-4 text-3xl font-bold text-white sm:text-4xl">Educational Insights Before You Invest</h2>
+              <p className="mx-auto mt-2 max-w-3xl text-base text-slate-300">
+                Understand how intelligent automation works, the safeguards leading platforms use, and what fees to expect compared to traditional advisors.
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              {faqItems.map((item) => (
+                <details
+                  key={item.question}
+                  className="group rounded-2xl border border-white/10 bg-[#081223] p-6 text-left transition hover:border-emerald-400/40"
+                >
+                  <summary className="flex cursor-pointer list-none items-center justify-between text-lg font-semibold text-white">
+                    {item.question}
+                    <span className="ml-4 flex h-8 w-8 items-center justify-center rounded-full border border-emerald-400/40 text-sm text-emerald-300 transition group-open:rotate-45">
+                      +
+                    </span>
+                  </summary>
+                  <p className="mt-4 text-sm text-slate-300">{item.answer}</p>
+                </details>
+              ))}
+            </div>
+          </section>
+
+          <section className="mt-16 overflow-hidden rounded-3xl bg-gradient-to-r from-emerald-400 via-emerald-500 to-cyan-500 p-[1px] shadow-[0_40px_120px_-70px_rgba(16,185,129,0.7)] motion-safe:animate-[fadeIn_0.8s_ease-out] motion-safe:[animation-delay:0.4s]">
+            <div className="flex flex-col items-start gap-6 rounded-3xl bg-[#041023] px-8 py-10 text-left sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-2">
+                <p className="text-sm font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                  Ready to invest smarter?
+                </p>
+                <h3 className="text-2xl font-bold text-white sm:text-3xl">
+                  Start comparing AI investing platforms now.
+                </h3>
+                <p className="text-sm text-slate-300">
+                  Unlock deep-dive reviews, score breakdowns, and exclusive promotions tailored to automation-first investors.
+                </p>
+              </div>
+              <Link
+                to="/offers"
+                className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#041023] shadow-lg transition hover:brightness-110"
+              >
+                Compare Offers
+              </Link>
+            </div>
+          </section>
+        </div>
       </div>
-    </div>
+    </Layout>
   );
 }

--- a/src/pages/offers.jsx
+++ b/src/pages/offers.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
+import Layout from "@/components/layout/Layout";
 import ScoreBadge from "../components/score/ScoreBadge";
 import ScoreTicker from "../components/score/ScoreTicker";
 import BrokerBox from "../components/offers/BrokerBox";
@@ -103,242 +104,244 @@ export default function OffersPage() {
   }, [sortedOffers]);
 
   return (
-    <div className="bg-[#050B1A] text-slate-100">
-      <ScoreTicker brokers={sortedOffers} />
+    <Layout>
+      <div className="bg-[#050B1A] text-slate-100">
+        <ScoreTicker brokers={sortedOffers} />
 
-      <div className="mx-auto max-w-6xl px-4 pb-24">
-        <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)]">
-          <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
-            <div className="space-y-6">
-              <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
-                MyFreeStock Score™
-              </div>
-              <div>
-                <h1 className="text-4xl font-extrabold tracking-tight text-white sm:text-5xl lg:text-6xl">
-                  The MyFreeStock Score™ System
-                </h1>
-                <p className="mt-4 text-lg text-slate-300">
-                  Independent ratings for brokers and robo-advisors
+        <div className="mx-auto max-w-6xl px-4 pb-24">
+          <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)]">
+            <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+              <div className="space-y-6">
+                <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                  MyFreeStock Score™
+                </div>
+                <div>
+                  <h1 className="text-4xl font-extrabold tracking-tight text-white sm:text-5xl lg:text-6xl">
+                    The MyFreeStock Score™ System
+                  </h1>
+                  <p className="mt-4 text-lg text-slate-300">
+                    Independent ratings for brokers and robo-advisors
+                  </p>
+                </div>
+                <p className="text-base text-slate-300 sm:text-lg">
+                  The Score™ measures transparency, cost, platform features, customer support, and historical returns. Each category is weighted into a 0–100 composite that refreshes every week so you can track who leads the market in real time.
                 </p>
-              </div>
-              <p className="text-base text-slate-300 sm:text-lg">
-                The Score™ measures transparency, cost, platform features, customer support, and historical returns. Each category is weighted into a 0–100 composite that refreshes every week so you can track who leads the market in real time.
-              </p>
-              <div className="flex flex-wrap items-center gap-4">
-                <a
-                  href="#scores"
-                  className="rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/40 transition hover:scale-[1.02]"
-                >
-                  Compare All Scores
-                </a>
-                <Link
-                  to="/"
-                  className="rounded-full border border-emerald-400/40 px-6 py-3 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
-                >
-                  Back to Homepage
-                </Link>
-              </div>
-            </div>
-            {summary.topOffer && (
-              <div className="relative overflow-hidden rounded-[36px] border border-emerald-400/20 bg-[#0A152E] p-8 shadow-xl">
-                <div className="absolute inset-0 -translate-y-6 translate-x-6 rounded-[40px] bg-emerald-500/20 blur-3xl" />
-                <div className="relative space-y-6">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
-                      Highest Score This Week
-                    </span>
-                    <ScoreBadge score={summary.topOffer.computedScore} />
-                  </div>
-                  <div className="space-y-2">
-                    <p className="text-2xl font-bold text-white">{summary.topOffer.name}</p>
-                    <p className="text-sm text-slate-300">
-                      Our toolkit highlights standout offers where balanced pricing, robust tools, and long-term performance align.
-                    </p>
-                  </div>
-                  <div className="flex items-baseline justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-slate-300">
-                    <span>Scoreboard Average</span>
-                    <span className="text-xl font-semibold text-white">{summary.averageScore}</span>
-                  </div>
+                <div className="flex flex-wrap items-center gap-4">
                   <a
-                    href={summary.topOffer.cta?.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex w-full justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+                    href="#scores"
+                    className="rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/40 transition hover:scale-[1.02]"
                   >
-                    {summary.topOffer.cta?.label ?? "Claim Offer"}
+                    Compare All Scores
                   </a>
+                  <Link
+                    to="/"
+                    className="rounded-full border border-emerald-400/40 px-6 py-3 text-sm font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
+                  >
+                    Back to Homepage
+                  </Link>
                 </div>
               </div>
-            )}
-          </div>
-        </section>
+              {summary.topOffer && (
+                <div className="relative overflow-hidden rounded-[36px] border border-emerald-400/20 bg-[#0A152E] p-8 shadow-xl">
+                  <div className="absolute inset-0 -translate-y-6 translate-x-6 rounded-[40px] bg-emerald-500/20 blur-3xl" />
+                  <div className="relative space-y-6">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                        Highest Score This Week
+                      </span>
+                      <ScoreBadge score={summary.topOffer.computedScore} />
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-2xl font-bold text-white">{summary.topOffer.name}</p>
+                      <p className="text-sm text-slate-300">
+                        Our toolkit highlights standout offers where balanced pricing, robust tools, and long-term performance align.
+                      </p>
+                    </div>
+                    <div className="flex items-baseline justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-slate-300">
+                      <span>Scoreboard Average</span>
+                      <span className="text-xl font-semibold text-white">{summary.averageScore}</span>
+                    </div>
+                    <a
+                      href={summary.topOffer.cta?.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex w-full justify-center rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+                    >
+                      {summary.topOffer.cta?.label ?? "Claim Offer"}
+                    </a>
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
 
-        <section className="mt-10">
-          <div className="grid gap-4 rounded-3xl border border-emerald-400/20 bg-[#071025] p-6 sm:grid-cols-2 lg:grid-cols-5">
-            {[
-              { label: "Transparency", weight: "25%" },
-              { label: "Cost", weight: "20%" },
-              { label: "Features", weight: "20%" },
-              { label: "Support", weight: "15%" },
-              { label: "Returns", weight: "20%" },
-            ].map((metric) => (
-              <div
-                key={metric.label}
-                className="flex flex-col items-center rounded-2xl bg-white/5 p-4 text-center text-slate-200 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]"
-              >
-                <span className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/15 text-sm font-semibold text-emerald-300">
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    className="h-5 w-5"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 3v18m9-9H3"
-                    />
-                  </svg>
-                </span>
-                <p className="text-sm font-semibold text-white">{metric.label}</p>
-                <p className="mt-1 text-xs uppercase tracking-[0.25em] text-emerald-300">{metric.weight}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="mt-12 rounded-3xl border border-emerald-400/20 bg-[#09152B] p-10 text-slate-200 shadow-[0_30px_90px_-60px_rgba(16,185,129,0.6)]">
-          <div className="mx-auto max-w-4xl text-center">
-            <h2 className="text-3xl font-bold text-white sm:text-4xl">How We Calculate the Score</h2>
-            <p className="mt-4 text-base text-slate-300">
-              Each category is reviewed with a proprietary rubric that weights objective data, platform disclosures, and real user feedback. We rebalance weekly to reflect product launches, pricing shifts, and new regulatory updates.
-            </p>
-          </div>
-          <div className="mt-10 grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
-            <div className="space-y-4">
+          <section className="mt-10">
+            <div className="grid gap-4 rounded-3xl border border-emerald-400/20 bg-[#071025] p-6 sm:grid-cols-2 lg:grid-cols-5">
               {[
-                "Transparency digs into fee clarity and disclosures.",
-                "Cost covers commissions, spreads, and account minimums.",
-                "Features evaluate investing tools, automation, and integrations.",
-                "Support measures human and digital help options.",
-                "Returns tracks historical performance where disclosed.",
-              ].map((item) => (
-                <div key={item} className="flex items-start gap-3 rounded-2xl border border-emerald-400/10 bg-[#0B1A33] p-4">
-                  <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" />
-                  <p className="text-sm text-slate-200">{item}</p>
+                { label: "Transparency", weight: "25%" },
+                { label: "Cost", weight: "20%" },
+                { label: "Features", weight: "20%" },
+                { label: "Support", weight: "15%" },
+                { label: "Returns", weight: "20%" },
+              ].map((metric) => (
+                <div
+                  key={metric.label}
+                  className="flex flex-col items-center rounded-2xl bg-white/5 p-4 text-center text-slate-200 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]"
+                >
+                  <span className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/15 text-sm font-semibold text-emerald-300">
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      className="h-5 w-5"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M12 3v18m9-9H3"
+                      />
+                    </svg>
+                  </span>
+                  <p className="text-sm font-semibold text-white">{metric.label}</p>
+                  <p className="mt-1 text-xs uppercase tracking-[0.25em] text-emerald-300">{metric.weight}</p>
                 </div>
               ))}
             </div>
-            <div className="flex items-center justify-center">
-              <div className="relative flex h-56 w-56 items-center justify-center rounded-full border-2 border-emerald-400/40 bg-[#0B1A33] shadow-inner shadow-emerald-500/20">
-                <div className="absolute inset-4 rounded-full border border-emerald-400/30" />
-                <div className="absolute inset-2 rounded-full bg-gradient-to-br from-emerald-500/20 via-transparent to-transparent" />
-                <div className="text-center">
-                  <p className="text-xs uppercase tracking-[0.25em] text-emerald-300">Weighting</p>
-                  <p className="mt-2 text-3xl font-bold text-white">0 – 100</p>
-                  <p className="mt-1 text-xs text-slate-300">Updated Weekly</p>
+          </section>
+
+          <section className="mt-12 rounded-3xl border border-emerald-400/20 bg-[#09152B] p-10 text-slate-200 shadow-[0_30px_90px_-60px_rgba(16,185,129,0.6)]">
+            <div className="mx-auto max-w-4xl text-center">
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">How We Calculate the Score</h2>
+              <p className="mt-4 text-base text-slate-300">
+                Each category is reviewed with a proprietary rubric that weights objective data, platform disclosures, and real user feedback. We rebalance weekly to reflect product launches, pricing shifts, and new regulatory updates.
+              </p>
+            </div>
+            <div className="mt-10 grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+              <div className="space-y-4">
+                {[
+                  "Transparency digs into fee clarity and disclosures.",
+                  "Cost covers commissions, spreads, and account minimums.",
+                  "Features evaluate investing tools, automation, and integrations.",
+                  "Support measures human and digital help options.",
+                  "Returns tracks historical performance where disclosed.",
+                ].map((item) => (
+                  <div key={item} className="flex items-start gap-3 rounded-2xl border border-emerald-400/10 bg-[#0B1A33] p-4">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" />
+                    <p className="text-sm text-slate-200">{item}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="flex items-center justify-center">
+                <div className="relative flex h-56 w-56 items-center justify-center rounded-full border-2 border-emerald-400/40 bg-[#0B1A33] shadow-inner shadow-emerald-500/20">
+                  <div className="absolute inset-4 rounded-full border border-emerald-400/30" />
+                  <div className="absolute inset-2 rounded-full bg-gradient-to-br from-emerald-500/20 via-transparent to-transparent" />
+                  <div className="text-center">
+                    <p className="text-xs uppercase tracking-[0.25em] text-emerald-300">Weighting</p>
+                    <p className="mt-2 text-3xl font-bold text-white">0 – 100</p>
+                    <p className="mt-1 text-xs text-slate-300">Updated Weekly</p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <section className="mt-12 rounded-3xl border border-emerald-400/20 bg-[#071025] p-10 shadow-[0_30px_90px_-70px_rgba(16,185,129,0.6)]">
-          <div className="flex flex-col gap-4 text-center">
-            <span className="mx-auto rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
-              Toolkit
-            </span>
-            <h2 className="text-3xl font-bold text-white sm:text-4xl">The MyFreeStocks Toolkit</h2>
-            <p className="mx-auto max-w-2xl text-base text-slate-300">
-              Pair the Score™ with specialized research workflows designed to keep your investing stack transparent and opportunity-ready.
-            </p>
-          </div>
-          <div className="mt-10 grid gap-6 md:grid-cols-3">
-            {[
-              {
-                title: "Free Stock Offer Tracker",
-                description:
-                  "Monitor every live brokerage incentive with auto-refreshing terms, deadlines, and funding requirements.",
-              },
-              {
-                title: "Robo-Advisor Comparison",
-                description:
-                  "Benchmark automation styles, portfolio mixes, and advisory fees with filters made for both beginners and pros.",
-              },
-              {
-                title: "Data Transparency Dashboard",
-                description:
-                  "Review disclosures, regulatory filings, and service-level agreements directly inside your Score™ workspace.",
-              },
-            ].map((tool) => (
-              <div
-                key={tool.title}
-                className="group flex flex-col gap-4 rounded-3xl border border-white/5 bg-[#0B1A33]/80 p-6 text-left shadow-[0_25px_60px_-50px_rgba(16,185,129,0.6)] transition hover:border-emerald-400/50 hover:shadow-emerald-500/20"
-              >
-                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-300">
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    className="h-6 w-6"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M4 7h16M4 12h16M4 17h10"
-                    />
-                  </svg>
-                </span>
-                <div className="space-y-2">
-                  <h3 className="text-xl font-semibold text-white">{tool.title}</h3>
-                  <p className="text-sm text-slate-300">{tool.description}</p>
+          <section className="mt-12 rounded-3xl border border-emerald-400/20 bg-[#071025] p-10 shadow-[0_30px_90px_-70px_rgba(16,185,129,0.6)]">
+            <div className="flex flex-col gap-4 text-center">
+              <span className="mx-auto rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                Toolkit
+              </span>
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">The MyFreeStocks Toolkit</h2>
+              <p className="mx-auto max-w-2xl text-base text-slate-300">
+                Pair the Score™ with specialized research workflows designed to keep your investing stack transparent and opportunity-ready.
+              </p>
+            </div>
+            <div className="mt-10 grid gap-6 md:grid-cols-3">
+              {[
+                {
+                  title: "Free Stock Offer Tracker",
+                  description:
+                    "Monitor every live brokerage incentive with auto-refreshing terms, deadlines, and funding requirements.",
+                },
+                {
+                  title: "Robo-Advisor Comparison",
+                  description:
+                    "Benchmark automation styles, portfolio mixes, and advisory fees with filters made for both beginners and pros.",
+                },
+                {
+                  title: "Data Transparency Dashboard",
+                  description:
+                    "Review disclosures, regulatory filings, and service-level agreements directly inside your Score™ workspace.",
+                },
+              ].map((tool) => (
+                <div
+                  key={tool.title}
+                  className="group flex flex-col gap-4 rounded-3xl border border-white/5 bg-[#0B1A33]/80 p-6 text-left shadow-[0_25px_60px_-50px_rgba(16,185,129,0.6)] transition hover:border-emerald-400/50 hover:shadow-emerald-500/20"
+                >
+                  <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-300">
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      className="h-6 w-6"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M4 7h16M4 12h16M4 17h10"
+                      />
+                    </svg>
+                  </span>
+                  <div className="space-y-2">
+                    <h3 className="text-xl font-semibold text-white">{tool.title}</h3>
+                    <p className="text-sm text-slate-300">{tool.description}</p>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section id="scores" className="mt-12">
-          <div className="flex flex-col gap-4 text-center">
-            <span className="mx-auto rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
-              Ranked Brokerages
-            </span>
-            <h2 className="text-3xl font-bold text-white sm:text-4xl">
-              Live MyFreeStock Score™ Leaderboard
-            </h2>
-            <p className="mx-auto max-w-3xl text-base text-slate-300">
-              Every score is recalculated as broker terms evolve. Use the cards below to explore score breakdowns and jump directly to each promotion.
-            </p>
-          </div>
-
-          <div className="mt-12 grid grid-cols-1 gap-6 sm:gap-7 md:grid-cols-2 lg:grid-cols-3">
-            {brokersLoading && (
-              <div className="md:col-span-2 xl:col-span-3">
-                <div className="rounded-3xl border border-white/5 bg-white/5 p-6 text-center text-sm text-slate-300">
-                  Loading verified offers…
-                </div>
-              </div>
-            )}
-            {brokersError && !brokersLoading && (
-              <div className="md:col-span-2 xl:col-span-3">
-                <div className="rounded-3xl border border-rose-500/40 bg-rose-500/10 p-6 text-center text-sm text-rose-200">
-                  We couldn&apos;t refresh the offers right now. Please try again shortly.
-                </div>
-              </div>
-            )}
-            {!brokersLoading && !brokersError &&
-              sortedOffers.map((offer, index) => (
-                <BrokerBox
-                  key={offer.id ?? offer.slug ?? index}
-                  offer={offer}
-                  isTopPick={index === 0}
-                />
               ))}
-          </div>
-        </section>
+            </div>
+          </section>
+
+          <section id="scores" className="mt-12">
+            <div className="flex flex-col gap-4 text-center">
+              <span className="mx-auto rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300">
+                Ranked Brokerages
+              </span>
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">
+                Live MyFreeStock Score™ Leaderboard
+              </h2>
+              <p className="mx-auto max-w-3xl text-base text-slate-300">
+                Every score is recalculated as broker terms evolve. Use the cards below to explore score breakdowns and jump directly to each promotion.
+              </p>
+            </div>
+
+            <div className="mt-12 grid grid-cols-1 gap-6 sm:gap-7 md:grid-cols-2 lg:grid-cols-3">
+              {brokersLoading && (
+                <div className="md:col-span-2 xl:col-span-3">
+                  <div className="rounded-3xl border border-white/5 bg-white/5 p-6 text-center text-sm text-slate-300">
+                    Loading verified offers…
+                  </div>
+                </div>
+              )}
+              {brokersError && !brokersLoading && (
+                <div className="md:col-span-2 xl:col-span-3">
+                  <div className="rounded-3xl border border-rose-500/40 bg-rose-500/10 p-6 text-center text-sm text-rose-200">
+                    We couldn&apos;t refresh the offers right now. Please try again shortly.
+                  </div>
+                </div>
+              )}
+              {!brokersLoading && !brokersError &&
+                sortedOffers.map((offer, index) => (
+                  <BrokerBox
+                    key={offer.id ?? offer.slug ?? index}
+                    offer={offer}
+                    isTopPick={index === 0}
+                  />
+                ))}
+            </div>
+          </section>
+        </div>
       </div>
-    </div>
+    </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- update the shared Layout to support nested usage so headers/footers are not duplicated
- wrap the Offers and RoboAdvisors pages with Layout and rely on the shared header/footer
- document the new layout policy requirement for the builder agent

## Testing
- `grep -rHn -E "<(header|footer|nav)" src/pages/`


------
https://chatgpt.com/codex/tasks/task_e_68e875a7546c83328a9401213f638f30