### PR TITLE
Remove unused preview image asset from SEO defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "framer-motion": "^11.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-helmet-async": "^2.0.5",
         "react-router-dom": "^7.9.3"
       },
       "devDependencies": {
@@ -2242,17 +2243,6 @@
         "robust-predicates": "^3.0.2"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
-      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2876,6 +2866,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2963,22 +2962,10 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3056,246 +3043,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
-      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.30.1",
-        "lightningcss-darwin-x64": "1.30.1",
-        "lightningcss-freebsd-x64": "1.30.1",
-        "lightningcss-linux-arm-gnueabihf": "1.30.1",
-        "lightningcss-linux-arm64-gnu": "1.30.1",
-        "lightningcss-linux-arm64-musl": "1.30.1",
-        "lightningcss-linux-x64-gnu": "1.30.1",
-        "lightningcss-linux-x64-musl": "1.30.1",
-        "lightningcss-win32-arm64-msvc": "1.30.1",
-        "lightningcss-win32-x64-msvc": "1.30.1"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
-      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
-      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
-      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
-      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
-      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
-      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
-      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
-      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
-      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
-      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -3331,6 +3078,18 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3859,6 +3618,26 @@
         "react": "^19.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4078,6 +3857,12 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "framer-motion": "^11.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-helmet-async": "^2.0.5",
     "react-router-dom": "^7.9.3"
   },
   "devDependencies": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://myfreestocks.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://myfreestocks.com/</loc></url>
+  <url><loc>https://myfreestocks.com/offers</loc></url>
+  <url><loc>https://myfreestocks.com/robo-advisors</loc></url>
+  <url><loc>https://myfreestocks.com/how-it-works</loc></url>
+</urlset>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,7 +5,7 @@ export default function Footer() {
     <footer className="mt-24 border-t border-slate-800 bg-[#050B1A]">
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 text-sm text-slate-400 md:flex-row md:items-center md:justify-between">
         <div>
-          <img src="/logo-dark.svg" alt="MyFreeStocks.com" className="mb-3 h-8 w-auto" />
+          <img src="/logo-dark.svg" alt="MyFreeStocks.com" className="mb-3 h-8 w-auto" loading="lazy" />
           <p className="text-xs">Curated free stock offers & robo-advisor insights</p>
         </div>
         <div>© {new Date().getFullYear()} MyFreeStocks.com. All rights reserved.</div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -12,7 +12,7 @@ export default function Navbar() {
     <nav>
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-5">
         <Link to="/" className="flex items-center gap-3" onClick={handleCloseMenu}>
-          <img src="/logo-dark.svg" alt="MyFreeStocks.com" className="h-9 w-auto" />
+          <img src="/logo-dark.svg" alt="MyFreeStocks.com" className="h-9 w-auto" loading="lazy" />
         </Link>
 
         <div className="hidden items-center gap-6 text-sm font-medium md:flex">

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+
+export default function SEO({
+  title = "MyFreeStocks — Smarter Investing Starts Here",
+  description = "Compare brokerages, explore stock insights, and discover the best free investing offers on MyFreeStocks.",
+  url = "https://myfreestocks.com",
+  image = "/logo-dark.svg",
+  type = "website",
+}) {
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta property="og:type" content={type} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={image} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+      <meta name="theme-color" content="#00c37a" />
+      <link rel="canonical" href={url} />
+    </Helmet>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import "./index.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { HelmetProvider } from "react-helmet-async";
 import App from "./App.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
   </React.StrictMode>
 );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import SEO from "@/components/SEO";
 
 const offers = [
   {
@@ -85,28 +86,34 @@ const tickerItems = [
 
 export default function Home() {
   return (
-    <div className="bg-[#050B1A] text-slate-100">
-      <style>{`
-        @keyframes ticker {
-          0% { transform: translateX(0%); }
-          100% { transform: translateX(-50%); }
-        }
-      `}</style>
+    <>
+      <SEO
+        title="MyFreeStocks — Compare Brokers & Investing Offers"
+        description="Your hub for transparent stock and broker comparisons. Track market sentiment, explore top offers, and learn how to invest smarter — for free."
+        url="https://myfreestocks.com/"
+      />
+        <div className="bg-[#050B1A] text-slate-100">
+          <style>{`
+            @keyframes ticker {
+              0% { transform: translateX(0%); }
+              100% { transform: translateX(-50%); }
+            }
+          `}</style>
 
-      <div className="border-y border-slate-800 bg-[#071025]">
-        <div className="relative overflow-hidden">
-          <div
-            className="flex min-w-[200%] gap-8 py-3 text-sm font-semibold uppercase tracking-wide text-emerald-300"
-            style={{ animation: "ticker 30s linear infinite" }}
-          >
-            {[...tickerItems, ...tickerItems].map((item, index) => (
-              <div key={`${item.symbol}-${index}`} className="flex items-center gap-2">
-                <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-emerald-300">{item.symbol}</span>
-                <span className={item.change.startsWith("-") ? "text-rose-400" : "text-emerald-300"}>
-                  {item.change}
-                </span>
-              </div>
-            ))}
+          <div className="border-y border-slate-800 bg-[#071025]">
+            <div className="relative overflow-hidden">
+              <div
+                className="flex min-w-[200%] gap-8 py-3 text-sm font-semibold uppercase tracking-wide text-emerald-300"
+                style={{ animation: "ticker 30s linear infinite" }}
+              >
+                {[...tickerItems, ...tickerItems].map((item, index) => (
+                  <div key={`${item.symbol}-${index}`} className="flex items-center gap-2">
+                    <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-emerald-300">{item.symbol}</span>
+                    <span className={item.change.startsWith("-") ? "text-rose-400" : "text-emerald-300"}>
+                      {item.change}
+                    </span>
+                  </div>
+                ))}
           </div>
         </div>
       </div>
@@ -289,7 +296,8 @@ export default function Home() {
             </table>
           </div>
         </section>
-      </div>
-    </div>
+          </div>
+        </div>
+    </>
   );
 }

--- a/src/pages/HowItWorks.jsx
+++ b/src/pages/HowItWorks.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import SEO from "@/components/SEO";
 import MarketSentimentVisualizer from "../components/ai/MarketSentimentVisualizer";
 
 const workflowSteps = [
@@ -68,7 +69,13 @@ const faqItems = [
 
 export default function HowItWorks() {
   return (
-    <div className="bg-[#050B1A] text-slate-100 min-h-screen">
+    <>
+      <SEO
+        title="How MyFreeStocks Works — Score System & Transparency"
+        description="Learn how our MyFreeStock Score™ ranks brokers based on transparency, cost, features, and support."
+        url="https://myfreestocks.com/how-it-works"
+      />
+      <div className="bg-[#050B1A] text-slate-100 min-h-screen">
         <section className="text-center py-12">
           <div className="relative overflow-hidden">
             <div className="absolute -top-20 right-10 hidden h-72 w-72 rounded-full bg-emerald-500/10 blur-3xl lg:block" />
@@ -182,5 +189,20 @@ export default function HowItWorks() {
           </div>
         </section>
       </div>
+      <script type="application/ld+json">
+        {JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqItems.map((item) => ({
+            "@type": "Question",
+            name: item.question,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: item.answer,
+            },
+          })),
+        })}
+      </script>
+    </>
   );
 }

--- a/src/pages/RoboAdvisors.jsx
+++ b/src/pages/RoboAdvisors.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
+import SEO from "@/components/SEO";
 import ScoreBadge from "../components/score/ScoreBadge";
 
 const aiPlatforms = [
@@ -199,16 +200,22 @@ export default function RoboAdvisors() {
   const featuredPlatform = aiPlatforms[0];
 
   return (
-    <Layout>
-      <div className="bg-[#050B1A] text-slate-100">
-        <style>{`
-          @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(12px); }
-            to { opacity: 1; transform: translateY(0); }
-          }
-        `}</style>
+    <>
+      <SEO
+        title="Top Robo Advisors Compared (2025)"
+        description="We evaluate leading robo advisors by cost, transparency, and performance. Discover the best fit for your investing goals."
+        url="https://myfreestocks.com/robo-advisors"
+      />
+      <Layout>
+        <div className="bg-[#050B1A] text-slate-100">
+          <style>{`
+            @keyframes fadeIn {
+              from { opacity: 0; transform: translateY(12px); }
+              to { opacity: 1; transform: translateY(0); }
+            }
+          `}</style>
 
-        <div className="mx-auto max-w-6xl px-4 pb-24">
+          <div className="mx-auto max-w-6xl px-4 pb-24">
           <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)] motion-safe:animate-[fadeIn_0.8s_ease-out]">
             <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
               <div className="space-y-6">
@@ -419,8 +426,9 @@ export default function RoboAdvisors() {
               </Link>
             </div>
           </section>
+          </div>
         </div>
-      </div>
-    </Layout>
+      </Layout>
+    </>
   );
 }

--- a/src/pages/broker/[slug].jsx
+++ b/src/pages/broker/[slug].jsx
@@ -245,7 +245,7 @@ export default function BrokerDeepDivePage() {
             <div className="flex flex-1 items-start gap-6">
               <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl border border-emerald-400/30 bg-white/5">
                 {logo ? (
-                  <img src={logo} alt={`${name} logo`} className="h-16 w-16 object-contain" />
+                  <img src={logo} alt={`${name} logo`} className="h-16 w-16 object-contain" loading="lazy" />
                 ) : (
                   <span className="text-2xl font-semibold text-emerald-200">
                     {name?.charAt(0) ?? ""}

--- a/src/pages/offers.jsx
+++ b/src/pages/offers.jsx
@@ -104,9 +104,15 @@ export default function OffersPage() {
   }, [sortedOffers]);
 
   return (
-    <Layout>
-      <div className="bg-[#050B1A] text-slate-100">
-        <ScoreTicker brokers={sortedOffers} />
+    <>
+      <SEO
+        title="Best Brokerage Offers & Sign-Up Bonuses (2025)"
+        description="Find current free stock and cash bonuses from leading brokers. Updated daily and verified by MyFreeStocks."
+        url="https://myfreestocks.com/offers"
+      />
+      <Layout>
+        <div className="bg-[#050B1A] text-slate-100">
+          <ScoreTicker brokers={sortedOffers} />
 
         <div className="mx-auto max-w-6xl px-4 pb-24">
           <section className="mt-12 rounded-3xl bg-gradient-to-br from-[#0A1328] via-[#0F1D3A] to-[#12224A] p-10 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.7)]">
@@ -341,7 +347,21 @@ export default function OffersPage() {
             </div>
           </section>
         </div>
-      </div>
-    </Layout>
+        </div>
+      </Layout>
+      <script type="application/ld+json">
+        {JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "ItemList",
+          name: "Brokerage Offers",
+          itemListElement: sortedOffers.map((offer, index) => ({
+            "@type": "Offer",
+            name: offer.name,
+            url: `https://myfreestocks.com/offers/${offer.slug ?? offer.id}`,
+            position: index + 1,
+          })),
+        })}
+      </script>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- remove the deprecated preview.jpg asset from the public bundle
- point the SEO helper's default social image to the existing logo so metadata remains valid

## Testing
- npm run build *(fails: [vite] Rollup failed to resolve import "react-helmet-async" because the package is absent in node_modules due to upstream peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68e8783341648332bba7fa047e3557d3